### PR TITLE
Issue #37 added directors hash for config via hiera

### DIFF
--- a/manifests/webui.pp
+++ b/manifests/webui.pp
@@ -18,6 +18,7 @@ class bareos::webui(
   $pagination_default_value = 25,
   $save_previous_state = false,
   $label_pooltype = '',
+  $directors = {},
 ) inherits ::bareos {
 
   if $manage_package {
@@ -71,4 +72,6 @@ class bareos::webui(
       dir_address => 'localhost'
     }
   }
+
+  create_resources(::bareos::webui::director, $directors)
 }

--- a/spec/classes/webui_spec.rb
+++ b/spec/classes/webui_spec.rb
@@ -4,4 +4,23 @@ describe 'bareos::webui' do
     it { is_expected.to compile }
     it { is_expected.to contain_class('bareos') }
   end
+  context 'with directors => { test: { dir_address: "example.org", catalog: "MyCatalog" }}}' do
+    let(:params) do
+      {
+        directors: {
+          test: {
+            dir_address: 'example.org',
+            catalog: 'MyCatalog'
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile }
+    it do
+      is_expected.to contain_bareos__webui__director('test')
+        .with_dir_address('example.org')
+        .with_catalog('MyCatalog')
+    end
+  end
 end


### PR DESCRIPTION
This is the patch for https://github.com/voxpupuli/puppet-bareos/issues/37
With this it is possible to specify directors for the webui in hiera.