### PR TITLE
configurable $config_director_dirs with purge option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ rvm:
 cache: bundler
 script: bundle exec rake test
 env:
-  - PUPPET_GEM_VERSION="~> 3.4.0"
-  - PUPPET_GEM_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
   - PUPPET_GEM_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 4.4.0" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 4.6.0" STRICT_VARIABLES=yes
@@ -31,28 +27,10 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 4.6.0" STRICT_VARIABLES=yes
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 5.0.1" STRICT_VARIABLES=yes
-  - rvm: 2.1
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
   # eclude all puppet 3.x 5.x for ruby 2.3
-  - rvm: 2.3
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
-  - rvm: 2.3
-    env: PUPPET_GEM_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - rvm: 2.3
-    env: PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
-  - rvm: 2.3
-    env: PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
   - rvm: 2.3
     env: PUPPET_GEM_VERSION="~> 5.0.1" STRICT_VARIABLES=yes
   # eclude all puppet 3.x 4.x for ruby 2.4
-  - rvm: 2.4
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
-  - rvm: 2.4
-    env: PUPPET_GEM_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - rvm: 2.4
-    env: PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
-  - rvm: 2.4
-    env: PUPPET_GEM_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
   - rvm: 2.4
     env: PUPPET_GEM_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
   - rvm: 2.4

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -5,15 +5,16 @@
 # This class will be automatically included when a resource is defined.
 # It is not intended to be used directly by external resources like node definitions or other modules.
 class bareos::director(
-  $manage_service  = $::bareos::manage_service,
-  $manage_package  = $::bareos::manage_package,
-  $manage_database = $::bareos::manage_database,
-  $package_name    = $::bareos::director_package_name,
-  $package_ensure  = $::bareos::package_ensure,
-  $service_name    = $::bareos::director_service_name,
-  $service_ensure  = $::bareos::service_ensure,
-  $service_enable  = $::bareos::service_enable,
-  $config_dir      = "${::bareos::config_dir}/bareos-dir.d"
+  $manage_service             = $::bareos::manage_service,
+  $manage_package             = $::bareos::manage_package,
+  $manage_database            = $::bareos::manage_database,
+  $package_name               = $::bareos::director_package_name,
+  $package_ensure             = $::bareos::package_ensure,
+  $service_name               = $::bareos::director_service_name,
+  $service_ensure             = $::bareos::service_ensure,
+  $service_enable             = $::bareos::service_enable,
+  $config_dir                 = "${::bareos::config_dir}/bareos-dir.d",
+  Array[String] $managed_dirs = $::bareos::director_managed_dirs,
 ) inherits ::bareos {
   include ::bareos::director::director
 
@@ -32,28 +33,8 @@ class bareos::director(
     }
   }
 
-  # directories
-  $config_director_dirs = [
-    $config_dir,
-    "${config_dir}/catalog",
-    "${config_dir}/client",
-    "${config_dir}/console",
-    "${config_dir}/counter",
-    "${config_dir}/director",
-    "${config_dir}/fileset",
-    "${config_dir}/job",
-    "${config_dir}/jobdefs",
-    "${config_dir}/messages",
-    "${config_dir}/pool",
-    "${config_dir}/profile",
-    "${config_dir}/schedule",
-    "${config_dir}/storage",
-  ]
-
-  file { $config_director_dirs:
+  file { $config_dir:
     ensure  => directory,
-    purge   => true,
-    recurse => true,
     force   => true,
     mode    => $::bareos::file_dir_mode,
     owner   => $::bareos::file_owner,
@@ -61,6 +42,21 @@ class bareos::director(
     require => Package[$package_name],
     notify  => Service[$service_name],
     tag     => ['bareos', 'bareos_director'],
+  }
+
+  $managed_dirs.each |$managed_dir| {
+    file { "${config_dir}/${managed_dir}":
+      ensure  => directory,
+      purge   => true,
+      recurse => true,
+      force   => true,
+      require => Package[$package_name],
+      mode    => $::bareos::file_dir_mode,
+      owner   => $::bareos::file_owner,
+      group   => $::bareos::file_group,
+      notify  => Service[$service_name],
+      tag     => ['bareos', 'bareos_director'],
+    }
   }
 
   if $manage_database {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class bareos (
   $monitor_package_name  = $::bareos::params::monitor_package_name,
   $director_package_name = $::bareos::params::director_package_name,
   $director_service_name = $::bareos::params::director_service_name,
+  $director_managed_dirs = $::bareos::params::director_managed_dirs,
   $client_package_name   = $::bareos::params::client_package_name,
   $client_service_name   = $::bareos::params::client_service_name,
   $storage_package_name  = $::bareos::params::storage_package_name,
@@ -66,13 +67,13 @@ class bareos (
   }
 
   file { $config_dir:
-    ensure  => directory,
-    purge   => true,
-    recurse => true,
-    force   => true,
-    mode    => $::bareos::file_dir_mode,
-    owner   => $::bareos::file_owner,
-    group   => $::bareos::file_group,
-    tag     => ['bareos', 'bareos_core'],
+    ensure       => directory,
+    purge        => true,
+    recurse      => true,
+    recurselimit => 1,
+    mode         => $::bareos::file_dir_mode,
+    owner        => $::bareos::file_owner,
+    group        => $::bareos::file_group,
+    tag          => ['bareos', 'bareos_core'],
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,20 @@ class bareos::params {
     'bareos-database-tools',
   ]
   $director_service_name = 'bareos-dir'
+  $director_managed_dirs = [ 'catalog',
+                            'client',
+                            'console',
+                            'counter',
+                            'director',
+                            'fileset',
+                            'job',
+                            'jobdefs',
+                            'messages',
+                            'pool',
+                            'profile',
+                            'schedule',
+                            'storage',
+                          ]
 
   # filedaemon/client
   $client_package_name = ['bareos-filedaemon', 'bareos-filedaemon-python-plugin']


### PR DESCRIPTION
So I added the `$config_director_dirs` parameter to the bareos::director class as mentioned in #42 and removed the `recurse` from the bareos class in order allow directories not managed by puppet.