### PR TITLE
added possibility to configure defined types via hiera

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 4.6.0" STRICT_VARIABLES=yes
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 5.0.1" STRICT_VARIABLES=yes
-  # eclude all puppet 3.x 5.x for ruby 2.3
   - rvm: 2.3
     env: PUPPET_GEM_VERSION="~> 5.0.1" STRICT_VARIABLES=yes
   # eclude all puppet 3.x 4.x for ruby 2.4

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   1. [Monitor (Tray)](#monitor)
   1. [Storage](#storage)
   1. [Web UI](#webui)
+  1. [Hiera](#hiera)
 1. [Limitations - OS compatibility, etc.](#limitations)
 
 ## Description
@@ -390,6 +391,31 @@ Additional configuration is required on the **Director** server.
   where_acl          => '*all*',
 }
 ```
+
+### Hiera
+Since define ressource are used in the module they can not be used directly via hiera. Execptions are ofcourse the three classes mentioned in [Reference](#reference).
+But there exist hashes for the configuration directives in the `bareos::director` and the `bareos::webui` classes which can be used via hiera.
+
+```
+classes:
+  - bareos::director
+bareos::director::director::name_director: 'example'
+bareos::director::director::password: 'foobar'
+bareos::director::catalogs:
+  'testing':
+    db_driver: 'postgresql'
+    db_name: 'test'
+bareos::director::clients:
+  'alice':
+    address: foo.bar
+    password: foobar
+bareos::director::jobs:
+  'backup-alice':
+    messages: testing
+    pool: testing
+    type: backup
+    client: alice
+    file_set: testing
 
 ## Limitations
 

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -15,6 +15,19 @@ class bareos::director(
   $service_enable             = $::bareos::service_enable,
   $config_dir                 = "${::bareos::config_dir}/bareos-dir.d",
   Array[String] $managed_dirs = $::bareos::director_managed_dirs,
+  Optional[Hash] $catalogs    = {},
+  Optional[Hash] $clients     = {},
+  Optional[Hash] $consoles    = {},
+  Optional[Hash] $counters    = {},
+  Optional[Hash] $directors   = {},
+  Optional[Hash] $filesets    = {},
+  Optional[Hash] $jobs        = {},
+  Optional[Hash] $jobdefs     = {},
+  Optional[Hash] $messages    = {},
+  Optional[Hash] $pools       = {},
+  Optional[Hash] $profiles    = {},
+  Optional[Hash] $schedules   = {},
+  Optional[Hash] $storages    = {},
 ) inherits ::bareos {
   include ::bareos::director::director
 
@@ -67,4 +80,18 @@ class bareos::director(
       tag         => ['bareos', 'bareos_director'],
     }
   }
+
+  create_resources(::bareos::director::client, $clients)
+  create_resources(::bareos::director::catalog, $catalogs)
+  create_resources(::bareos::director::consoles, $consoles)
+  create_resources(::bareos::director::counters, $counters)
+  create_resources(::bareos::director::directors, $directors)
+  create_resources(::bareos::director::filesets, $filesets)
+  create_resources(::bareos::director::jobs, $jobs)
+  create_resources(::bareos::director::jobdefs, $jobdefs)
+  create_resources(::bareos::director::messages, $messages)
+  create_resources(::bareos::director::pools, $pools)
+  create_resources(::bareos::director::profiles, $profiles)
+  create_resources(::bareos::director::schedules, $schedules)
+  create_resources(::bareos::director::storages, $storages)
 }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -82,57 +82,57 @@ class bareos::director(
   }
 
   $catalogs.each |String $resource, Hash $attributes| {
-    bareos::director::catalog {
+    bareos::director::catalog { $resource:
       * => $attributes;
     }
   }
   $clients.each |String $resource, Hash $attributes| {
-    bareos::director::client {
+    bareos::director::client { $resource:
       * => $attributes;
     }
   }
   $consoles.each |String $resource, Hash $attributes| {
-    bareos::director::console {
+    bareos::director::console { $resource:
       * => $attributes;
     }
   }
   $filesets.each |String $resource, Hash $attributes| {
-    bareos::director::fileset {
+    bareos::director::fileset { $resource:
       * => $attributes;
     }
   }
   $jobs.each |String $resource, Hash $attributes| {
-    bareos::director::job {
+    bareos::director::job { $resource:
       * => $attributes;
     }
   }
   $jobdefs.each |String $resource, Hash $attributes| {
-    bareos::director::jobdefs {
+    bareos::director::jobdefs { $resource:
       * => $attributes;
     }
   }
   $messages.each |String $resource, Hash $attributes| {
-    bareos::director::messages {
+    bareos::director::messages { $resource:
       * => $attributes;
     }
   }
   $pools.each |String $resource, Hash $attributes| {
-    bareos::director::pool {
+    bareos::director::pool { $resource:
       * => $attributes;
     }
   }
   $profiles.each |String $resource, Hash $attributes| {
-    bareos::director::profile {
+    bareos::director::profile { $resource:
       * => $attributes;
     }
   }
   $schedules.each |String $resource, Hash $attributes| {
-    bareos::director::schedule {
+    bareos::director::schedule { $resource:
       * => $attributes;
     }
   }
   $storages.each |String $resource, Hash $attributes| {
-    bareos::director::storage {
+    bareos::director::storage { $resource:
       * => $attributes;
     }
   }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -81,8 +81,8 @@ class bareos::director(
     }
   }
 
-  create_resources(::bareos::director::client, $clients)
   create_resources(::bareos::director::catalog, $catalogs)
+  create_resources(::bareos::director::client, $clients)
   create_resources(::bareos::director::consoles, $consoles)
   create_resources(::bareos::director::counters, $counters)
   create_resources(::bareos::director::directors, $directors)

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -15,19 +15,19 @@ class bareos::director(
   $service_enable             = $::bareos::service_enable,
   $config_dir                 = "${::bareos::config_dir}/bareos-dir.d",
   Array[String] $managed_dirs = $::bareos::director_managed_dirs,
-  Optional[Hash] $catalogs    = {},
-  Optional[Hash] $clients     = {},
-  Optional[Hash] $consoles    = {},
-  Optional[Hash] $counters    = {},
-  Optional[Hash] $directors   = {},
-  Optional[Hash] $filesets    = {},
-  Optional[Hash] $jobs        = {},
-  Optional[Hash] $jobdefs     = {},
-  Optional[Hash] $messages    = {},
-  Optional[Hash] $pools       = {},
-  Optional[Hash] $profiles    = {},
-  Optional[Hash] $schedules   = {},
-  Optional[Hash] $storages    = {},
+  Hash $catalogs              = {},
+  Hash $clients               = {},
+  Hash $consoles              = {},
+  Hash $counters              = {},
+  Hash $directors             = {},
+  Hash $filesets              = {},
+  Hash $jobs                  = {},
+  Hash $jobdefs               = {},
+  Hash $messages              = {},
+  Hash $pools                 = {},
+  Hash $profiles              = {},
+  Hash $schedules             = {},
+  Hash $storages              = {},
 ) inherits ::bareos {
   include ::bareos::director::director
 
@@ -82,70 +82,58 @@ class bareos::director(
   }
 
   $catalogs.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::catalog] {
-      $resource: * => $attributes;
+    bareos::director::catalog {
+      * => $attributes;
     }
   }
   $clients.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::client] {
-      $resource: * => $attributes;
+    bareos::director::client {
+      * => $attributes;
     }
   }
   $consoles.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::console] {
-      $resource: * => $attributes;
+    bareos::director::console {
+      * => $attributes;
     }
   }
   $filesets.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::fileset] {
-      $resource: * => $attributes;
+    bareos::director::fileset {
+      * => $attributes;
     }
   }
   $jobs.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::job] {
-      $resource: * => $attributes;
+    bareos::director::job {
+      * => $attributes;
     }
   }
   $jobdefs.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::jobdefs] {
-      $resource: * => $attributes;
+    bareos::director::jobdefs {
+      * => $attributes;
     }
   }
   $messages.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::messages] {
-      $resource: * => $attributes;
+    bareos::director::messages {
+      * => $attributes;
     }
   }
   $pools.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::pool] {
-      $resource: * => $attributes;
+    bareos::director::pool {
+      * => $attributes;
     }
   }
   $profiles.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::profile] {
-      $resource: * => $attributes;
+    bareos::director::profile {
+      * => $attributes;
     }
   }
   $schedules.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::schedule] {
-      $resource: * => $attributes;
+    bareos::director::schedule {
+      * => $attributes;
     }
   }
   $storages.each |String $resource, Hash $attributes| {
-    Resource[::bareos::director::storage] {
-      $resource: * => $attributes;
+    bareos::director::storage {
+      * => $attributes;
     }
   }
-  create_resources(::bareos::director::client, $clients)
-  create_resources(::bareos::director::consoles, $consoles)
-  create_resources(::bareos::director::counters, $counters)
-  create_resources(::bareos::director::directors, $directors)
-  create_resources(::bareos::director::filesets, $filesets)
-  create_resources(::bareos::director::jobs, $jobs)
-  create_resources(::bareos::director::jobdefs, $jobdefs)
-  create_resources(::bareos::director::messages, $messages)
-  create_resources(::bareos::director::pools, $pools)
-  create_resources(::bareos::director::profiles, $profiles)
-  create_resources(::bareos::director::schedules, $schedules)
-  create_resources(::bareos::director::storages, $storages)
 }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -5,6 +5,7 @@
 # This class will be automatically included when a resource is defined.
 # It is not intended to be used directly by external resources like node definitions or other modules.
 class bareos::director(
+<<<<<<< HEAD
   $manage_service             = $::bareos::manage_service,
   $manage_package             = $::bareos::manage_package,
   $manage_database            = $::bareos::manage_database,
@@ -28,6 +29,30 @@ class bareos::director(
   Optional[Hash] $profiles    = {},
   Optional[Hash] $schedules   = {},
   Optional[Hash] $storages    = {},
+=======
+  $manage_service           = $::bareos::manage_service,
+  $manage_package           = $::bareos::manage_package,
+  $manage_database          = $::bareos::manage_database,
+  $package_name             = $::bareos::director_package_name,
+  $package_ensure           = $::bareos::package_ensure,
+  $service_name             = $::bareos::director_service_name,
+  $service_ensure           = $::bareos::service_ensure,
+  $service_enable           = $::bareos::service_enable,
+  $config_dir               = "${::bareos::config_dir}/bareos-dir.d",
+  Optional[Hash] $catalogs  = {},
+  Optional[Hash] $clients   = {},
+  Optional[Hash] $consoles  = {},
+  Optional[Hash] $counters  = {},
+  Optional[Hash] $directors = {},
+  Optional[Hash] $filesets  = {},
+  Optional[Hash] $jobs      = {},
+  Optional[Hash] $jobdefs   = {},
+  Optional[Hash] $messages  = {},
+  Optional[Hash] $pools     = {},
+  Optional[Hash] $profiles  = {},
+  Optional[Hash] $schedules = {},
+  Optional[Hash] $storages  = {},
+>>>>>>> fixup typo
 ) inherits ::bareos {
   include ::bareos::director::director
 

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -5,7 +5,6 @@
 # This class will be automatically included when a resource is defined.
 # It is not intended to be used directly by external resources like node definitions or other modules.
 class bareos::director(
-<<<<<<< HEAD
   $manage_service             = $::bareos::manage_service,
   $manage_package             = $::bareos::manage_package,
   $manage_database            = $::bareos::manage_database,
@@ -29,30 +28,6 @@ class bareos::director(
   Optional[Hash] $profiles    = {},
   Optional[Hash] $schedules   = {},
   Optional[Hash] $storages    = {},
-=======
-  $manage_service           = $::bareos::manage_service,
-  $manage_package           = $::bareos::manage_package,
-  $manage_database          = $::bareos::manage_database,
-  $package_name             = $::bareos::director_package_name,
-  $package_ensure           = $::bareos::package_ensure,
-  $service_name             = $::bareos::director_service_name,
-  $service_ensure           = $::bareos::service_ensure,
-  $service_enable           = $::bareos::service_enable,
-  $config_dir               = "${::bareos::config_dir}/bareos-dir.d",
-  Optional[Hash] $catalogs  = {},
-  Optional[Hash] $clients   = {},
-  Optional[Hash] $consoles  = {},
-  Optional[Hash] $counters  = {},
-  Optional[Hash] $directors = {},
-  Optional[Hash] $filesets  = {},
-  Optional[Hash] $jobs      = {},
-  Optional[Hash] $jobdefs   = {},
-  Optional[Hash] $messages  = {},
-  Optional[Hash] $pools     = {},
-  Optional[Hash] $profiles  = {},
-  Optional[Hash] $schedules = {},
-  Optional[Hash] $storages  = {},
->>>>>>> fixup typo
 ) inherits ::bareos {
   include ::bareos::director::director
 
@@ -106,9 +81,66 @@ class bareos::director(
     }
   }
 
+<<<<<<< HEAD
 $catalogs.each |String $resource, Hash $attributes| {
   Resource[::bareos::director::catalog] {
     $resource: * => $attributes;
+=======
+  $catalogs.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::catalog] {
+      $resource: * => $attributes;
+    }
+  }
+  $clients.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::client] {
+      $resource: * => $attributes;
+    }
+  }
+  $consoles.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::console] {
+      $resource: * => $attributes;
+    }
+  }
+  $filesets.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::fileset] {
+      $resource: * => $attributes;
+    }
+  }
+  $jobs.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::job] {
+      $resource: * => $attributes;
+    }
+  }
+  $jobdefs.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::jobdefs] {
+      $resource: * => $attributes;
+    }
+  }
+  $messages.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::messages] {
+      $resource: * => $attributes;
+    }
+  }
+  $pools.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::pool] {
+      $resource: * => $attributes;
+    }
+  }
+  $profiles.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::profile] {
+      $resource: * => $attributes;
+    }
+  }
+  $schedules.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::schedule] {
+      $resource: * => $attributes;
+    }
+  }
+  $storages.each |String $resource, Hash $attributes| {
+    Resource[::bareos::director::storage] {
+      $resource: * => $attributes;
+    }
+>>>>>>> fix typo
   }
 }
   create_resources(::bareos::director::client, $clients)

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -81,11 +81,6 @@ class bareos::director(
     }
   }
 
-<<<<<<< HEAD
-$catalogs.each |String $resource, Hash $attributes| {
-  Resource[::bareos::director::catalog] {
-    $resource: * => $attributes;
-=======
   $catalogs.each |String $resource, Hash $attributes| {
     Resource[::bareos::director::catalog] {
       $resource: * => $attributes;
@@ -140,9 +135,7 @@ $catalogs.each |String $resource, Hash $attributes| {
     Resource[::bareos::director::storage] {
       $resource: * => $attributes;
     }
->>>>>>> fix typo
   }
-}
   create_resources(::bareos::director::client, $clients)
   create_resources(::bareos::director::consoles, $consoles)
   create_resources(::bareos::director::counters, $counters)

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -106,7 +106,11 @@ class bareos::director(
     }
   }
 
-  create_resources(::bareos::director::catalog, $catalogs)
+$catalogs.each |String $resource, Hash $attributes| {
+  Resource[::bareos::director::catalog] {
+    $resource: * => $attributes;
+  }
+}
   create_resources(::bareos::director::client, $clients)
   create_resources(::bareos::director::consoles, $consoles)
   create_resources(::bareos::director::counters, $counters)

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 describe 'bareos::director' do
-  #let(:pre_condition) { 'class {"::bareos::director::director": password => "password" }' }
+  let(:pre_condition) { 'class {"::bareos::director::director": password => "password" }' }
 
   context 'with default values for all parameters' do
     it { is_expected.to compile }

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -6,4 +6,23 @@ describe 'bareos::director' do
     it { is_expected.to compile }
     it { is_expected.to contain_class('bareos') }
   end
+  context 'with catalogs => { test: { db_driver: "sqlite", db_name: "test" }}}' do
+    let(:params) do
+      {
+        catalogs: {
+          test: {
+            db_driver: "sqlite",
+            db_name: "test",
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile }
+    it do
+      is_expected.to contain_bareos__director__catalog('test')
+        .with_db_driver('sqlite')
+        .with_db_name('test')
+    end
+  end
 end

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 describe 'bareos::director' do
-  let(:pre_condition) { 'class {"::bareos::director::director": password => "password" }' }
+  #let(:pre_condition) { 'class {"::bareos::director::director": password => "password" }' }
 
   context 'with default values for all parameters' do
     it { is_expected.to compile }

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 describe 'bareos::director' do
-  let(:pre_condition) { 'class {"::bareos::director::director": password => "password" }' }
-
   context 'with default values for all parameters' do
     it { is_expected.to compile }
     it { is_expected.to contain_class('bareos') }


### PR DESCRIPTION
This is the corresponding PR for #41 
Its based on the schema of #37 and allows to use all the defined types via a hiera hash which is then given to `create_resources()`