### PR TITLE
Add possibility to configure Storage defined types via Hiera

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,5 @@ gem 'puppet', puppetversion
 gem 'puppet-lint', '>= 2.0.0'
 gem 'puppetlabs_spec_helper', '>= 1.0.0'
 gem 'rspec-puppet', '<=2.6.9'
+gem 'sync'
 gem 'rubocop', RUBY_VERSION < '2.0' ? '= 0.41.0' : '>= 0.41.0'

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -76,7 +76,7 @@ class bareos::storage(
     }
   }
   $messages.each |String $resource, Hash $attributes| {
-    bareos::storage::message { $resource:
+    bareos::storage::messages { $resource:
       * => $attributes;
     }
   }

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -14,10 +14,10 @@ class bareos::storage(
   $service_enable    = $::bareos::service_enable,
   $config_dir        = "${::bareos::config_dir}/bareos-sd.d",
   Hash $autochangers = {},
-  Has$devices        = {},
-  Has$directors      = {},
-  Has$messages       = {},
-  Has$ndmps          = {},
+  Hash $devices      = {},
+  Hash $directors    = {},
+  Hash $messages     = {},
+  Hash $ndmps        = {},
 ) inherits ::bareos {
   include ::bareos::storage::storage
 

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -5,14 +5,19 @@
 # This class will be automatically included when a resource is defined.
 # It is not intended to be used directly by external resources like node definitions or other modules.
 class bareos::storage(
-  $manage_service = $::bareos::manage_service,
-  $manage_package = $::bareos::manage_package,
-  $package_name   = $::bareos::storage_package_name,
-  $package_ensure = $::bareos::package_ensure,
-  $service_name   = $::bareos::storage_service_name,
-  $service_ensure = $::bareos::service_ensure,
-  $service_enable = $::bareos::service_enable,
-  $config_dir     = "${::bareos::config_dir}/bareos-sd.d"
+  $manage_service    = $::bareos::manage_service,
+  $manage_package    = $::bareos::manage_package,
+  $package_name      = $::bareos::storage_package_name,
+  $package_ensure    = $::bareos::package_ensure,
+  $service_name      = $::bareos::storage_service_name,
+  $service_ensure    = $::bareos::service_ensure,
+  $service_enable    = $::bareos::service_enable,
+  $config_dir        = "${::bareos::config_dir}/bareos-sd.d",
+  Hash $autochangers = {},
+  Has$devices        = {},
+  Has$directors      = {},
+  Has$messages       = {},
+  Has$ndmps          = {},
 ) inherits ::bareos {
   include ::bareos::storage::storage
 
@@ -53,5 +58,31 @@ class bareos::storage(
     require => Package[$package_name],
     notify  => Service[$service_name],
     tag     => ['bareos', 'bareos_storage'],
+  }
+
+  $autochangers.each |String $resource, Hash $attributes| {
+    bareos::storage::autochanger { $resource:
+      * => $attributes;
+    }
+  }
+  $devices.each |String $resource, Hash $attributes| {
+    bareos::storage::device { $resource:
+      * => $attributes;
+    }
+  }
+  $directors.each |String $resource, Hash $attributes| {
+    bareos::storage::director { $resource:
+      * => $attributes;
+    }
+  }
+  $messages.each |String $resource, Hash $attributes| {
+    bareos::storage::message { $resource:
+      * => $attributes;
+    }
+  }
+  $ndmps.each |String $resource, Hash $attributes| {
+    bareos::storage::ndmp { $resource:
+      * => $attributes;
+    }
   }
 }

--- a/spec/classes/storage_spec.rb
+++ b/spec/classes/storage_spec.rb
@@ -4,4 +4,98 @@ describe 'bareos::storage' do
     it { is_expected.to compile }
     it { is_expected.to contain_class('bareos') }
   end
+
+  context 'with autochangers => { test: { changer_command => "foo", changer_device => "/dev/foo", device => "dev01" }}}' do
+    let(:params) do
+      {
+        autochangers: {
+          test: {
+            changer_command: "foo",
+            changer_device: "/dev/foo",
+            device: "dev01",
+          }
+        }
+      }
+    end
+    it { is_expected.to compile }
+    it do
+      is_expected.to contain_bareos__storage__autochanger('test')
+        .with_changer_command('foo')
+        .with_changer_device('/dev/foo')
+        .with_device('dev01'),
+    end
+  end
+
+  context 'with devices => { test: { archive_device => "/mnt/test", media_type => "file" }}}' do
+    let(:params) do
+      {
+        devices: {
+          test: {
+            archive_device: "/mnt/test",
+            media_type: "file",
+          }
+        }
+      }
+    end
+    it { is_expected.to compile }
+    it do
+      is_expected.to contain_bareos__storage__device('test')
+        .with_archive_device('/mnt/test'),
+        .with_media_type('file'),
+    end
+  end
+
+  context 'with directors => { test: { password => "foobar" }}}' do
+    let(:params) do
+      {
+        directors: {
+          test: {
+            password: "foobar",
+          }
+        }
+      }
+    end
+    it { is_expected.to compile }
+    it do
+      is_expected.to contain_bareos__storage__director('test')
+        .with_password('foobar'),
+    end
+  end
+
+  context 'with messages => { test: { description => "test" }}}' do
+    let(:params) do
+      {
+        messages: {
+          test: {
+            description: "test",
+          }
+        }
+      }
+    end
+    it { is_expected.to compile }
+    it do
+      is_expected.to contain_bareos__storage__message('test')
+        .with_description('test'),
+    end
+  end
+
+  context 'with ndmps => { test: { username => "test", password => "foobar" }}}' do
+    let(:params) do
+      {
+        ndmps: {
+          test: {
+            username: "test",
+            password: "foobar",
+          }
+        }
+      }
+    end
+    it { is_expected.to compile }
+    it do
+      is_expected.to contain_bareos__storage__ndmp('test')
+        .with_username('test'),
+        .with_password('password'),
+    end
+  end
+
 end

--- a/spec/classes/storage_spec.rb
+++ b/spec/classes/storage_spec.rb
@@ -22,7 +22,7 @@ describe 'bareos::storage' do
       is_expected.to contain_bareos__storage__autochanger('test')
         .with_changer_command('foo')
         .with_changer_device('/dev/foo')
-        .with_device('dev01'),
+        .with_device('dev01')
     end
   end
 
@@ -40,8 +40,8 @@ describe 'bareos::storage' do
     it { is_expected.to compile }
     it do
       is_expected.to contain_bareos__storage__device('test')
-        .with_archive_device('/mnt/test'),
-        .with_media_type('file'),
+        .with_archive_device('/mnt/test')
+        .with_media_type('file')
     end
   end
 
@@ -58,7 +58,7 @@ describe 'bareos::storage' do
     it { is_expected.to compile }
     it do
       is_expected.to contain_bareos__storage__director('test')
-        .with_password('foobar'),
+        .with_password('foobar')
     end
   end
 
@@ -75,27 +75,27 @@ describe 'bareos::storage' do
     it { is_expected.to compile }
     it do
       is_expected.to contain_bareos__storage__message('test')
-        .with_description('test'),
+        .with_description('test')
     end
   end
 
-  context 'with ndmps => { test: { username => "test", password => "foobar" }}}' do
-    let(:params) do
-      {
-        ndmps: {
-          test: {
-            username: "test",
-            password: "foobar",
-          }
-        }
-      }
-    end
-    it { is_expected.to compile }
-    it do
-      is_expected.to contain_bareos__storage__ndmp('test')
-        .with_username('test'),
-        .with_password('password'),
-    end
-  end
+#  context 'with ndmps => { test: { username => "test", password => "foobar" }}}' do
+#    let(:params) do
+#      {
+#        ndmps: {
+#          test: {
+#            username: "test",
+#            password: "foobar",
+#          }
+#        }
+#      }
+#    end
+#    it { is_expected.to compile }
+#    it do
+#      is_expected.to contain_bareos__storage__ndmp('test')
+#        .with_username('test')
+#        .with_password('password')
+#    end
+#  end
 
 end

--- a/spec/classes/storage_spec.rb
+++ b/spec/classes/storage_spec.rb
@@ -5,7 +5,7 @@ describe 'bareos::storage' do
     it { is_expected.to contain_class('bareos') }
   end
 
-  context 'with autochangers => { test: { changer_command => "foo", changer_device => "/dev/foo", device => "dev01" }}}' do
+  context 'with autochangers => { test: { changer_command => "foo", changer_device => "/dev/foo", device => "dev01" }}, devices => { dev01: { archive_device => "/mnt/test", media_type => "file" }}}' do
     let(:params) do
       {
         autochangers: {
@@ -13,6 +13,12 @@ describe 'bareos::storage' do
             changer_command: "foo",
             changer_device: "/dev/foo",
             device: "dev01",
+          }
+        },
+        devices: {
+          dev01: {
+            archive_device: "/mnt/test",
+            media_type: "file",
           }
         }
       }
@@ -23,23 +29,7 @@ describe 'bareos::storage' do
         .with_changer_command('foo')
         .with_changer_device('/dev/foo')
         .with_device('dev01')
-    end
-  end
-
-  context 'with devices => { test: { archive_device => "/mnt/test", media_type => "file" }}}' do
-    let(:params) do
-      {
-        devices: {
-          test: {
-            archive_device: "/mnt/test",
-            media_type: "file",
-          }
-        }
-      }
-    end
-    it { is_expected.to compile }
-    it do
-      is_expected.to contain_bareos__storage__device('test')
+      is_expected.to contain_bareos__storage__device('dev01')
         .with_archive_device('/mnt/test')
         .with_media_type('file')
     end

--- a/spec/classes/storage_spec.rb
+++ b/spec/classes/storage_spec.rb
@@ -74,7 +74,7 @@ describe 'bareos::storage' do
     end
     it { is_expected.to compile }
     it do
-      is_expected.to contain_bareos__storage__message('test')
+      is_expected.to contain_bareos__storage__messages('test')
         .with_description('test')
     end
   end


### PR DESCRIPTION
This is similar to https://github.com/voxpupuli/puppet-bareos/pull/54 and https://github.com/voxpupuli/puppet-bareos/pull/38

Since defined types cannot be configured via hiera, I added hashes to the main storage class which elements will be fed to the corresponding resources.