### PR TITLE
Add RSpec test for storage::ndmps

### DIFF
--- a/spec/classes/storage_spec.rb
+++ b/spec/classes/storage_spec.rb
@@ -78,24 +78,25 @@ describe 'bareos::storage' do
         end
       end
 
-      #  context 'with ndmps => { test: { username => "test", password => "foobar" }}}' do
-      #    let(:params) do
-      #      {
-      #        ndmps: {
-      #          test: {
-      #            username: "test",
-      #            password: "foobar",
-      #          }
-      #        }
-      #      }
-      #    end
-      #    it { is_expected.to compile }
-      #    it do
-      #      is_expected.to contain_bareos__storage__ndmp('test')
-      #        .with_username('test')
-      #        .with_password('password')
-      #    end
-      #  end
+      context 'with ndmps => { test: { username => "test", password => "foobar" }}}' do
+        let(:params) do
+          {
+            ndmps: {
+              test: {
+                username: 'test',
+                password: 'foobar'
+              }
+            }
+          }
+        end
+
+        it { is_expected.to compile }
+        it do
+          is_expected.to contain_bareos__storage__ndmp('test').
+            with_username('test').
+            with_password('foobar')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This is a fixup for my last PR https://github.com/voxpupuli/puppet-bareos/pull/64

#### This Pull Request (PR) fixes the following issues
It just adds a rspec test to test if the hash `bareos::storage::ndmps` correctly creates `bareos::storage::ndmp` defines
