### PR TITLE
 Add missing parameter "count" to storage/device

### DIFF
--- a/manifests/storage/device.pp
+++ b/manifests/storage/device.pp
@@ -147,6 +147,13 @@
 #   Bareos Default: true
 #   Required: false
 #
+# [*count*]
+#   Count
+#
+#   Bareos Datatype: pint32
+#   Bareos Default: 1
+#   Required: false
+#
 # [*description*]
 #   Description: The Description directive provides easier human recognition, but is not used by Bareos directly.
 #
@@ -456,6 +463,7 @@ define bareos::storage::device (
   $check_labels = undef,
   $close_on_poll = undef,
   $collect_statistics = undef,
+  $count = undef,
   $description = undef,
   $device_options = undef,
   $device_type = undef,
@@ -530,6 +538,7 @@ define bareos::storage::device (
       [$check_labels, 'Check Labels', 'bit', false],
       [$close_on_poll, 'Close On Poll', 'bit', false],
       [$collect_statistics, 'Collect Statistics', 'boolean', false],
+      [$count, 'Count', 'pint32', false],
       [$device_options, 'Device Options', 'string', false],
       [$device_type, 'Device Type', 'device_type', false],
       [$diagnostic_device, 'Diagnostic Device', 'strname', false],

--- a/spec/defines/storage/storage_device_spec.rb
+++ b/spec/defines/storage/storage_device_spec.rb
@@ -53,6 +53,7 @@ describe 'bareos::storage::device' do
           param('changer_device', 'Changer Device', 'strname').
           param('check_labels', 'Check Labels', 'bit').
           param('close_on_poll', 'Close On Poll', 'bit').
+          param('count', 'Count', 'pint32').
           param('collect_statistics', 'Collect Statistics', 'boolean').
           param('device_options', 'Device Options', 'string').
           param('device_type', 'Device Type', 'device_type').

--- a/spec/defines/storage/storage_device_spec.rb
+++ b/spec/defines/storage/storage_device_spec.rb
@@ -53,8 +53,8 @@ describe 'bareos::storage::device' do
           param('changer_device', 'Changer Device', 'strname').
           param('check_labels', 'Check Labels', 'bit').
           param('close_on_poll', 'Close On Poll', 'bit').
-          param('count', 'Count', 'pint32').
           param('collect_statistics', 'Collect Statistics', 'boolean').
+          param('count', 'Count', 'pint32').
           param('device_options', 'Device Options', 'string').
           param('device_type', 'Device Type', 'device_type').
           param('diagnostic_device', 'Diagnostic Device', 'strname').


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This add the `count` parameter for storage devices

#### This Pull Request (PR) fixes the following issues
Fixes #73