### PR TITLE
Use reload instead of restart for director

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -11,6 +11,7 @@ class bareos::director (
   $package_name               = $bareos::director_package_name,
   $package_ensure             = $bareos::package_ensure,
   $service_name               = $bareos::director_service_name,
+  $service_allow_restart      = $bareos::director_service_allow_restart,
   $service_ensure             = $bareos::service_ensure,
   $service_enable             = $bareos::service_enable,
   $config_dir                 = "${bareos::config_dir}/bareos-dir.d",
@@ -37,9 +38,11 @@ class bareos::director (
     }
   }
 
-  $reload_command = $::facts['service_provider'] ? {
-    'systemd' => "systemctl ${service_name} reload",
-    default   => "service reload ${service_name}",
+  unless $service_allow_restart {
+    $reload_command = $::facts['service_provider'] ? {
+      'systemd' => "systemctl reload ${service_name}",
+      default   => "service ${service_name} relaod",
+    }
   }
 
   if $manage_service {

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -39,7 +39,7 @@ class bareos::director (
   }
 
   unless $service_allow_restart {
-    $reload_command = $::facts['service_provider'] ? {
+    $reload_command = $facts['service_provider'] ? {
       'systemd' => "systemctl reload ${service_name}",
       default   => "service ${service_name} relaod",
     }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -37,11 +37,18 @@ class bareos::director (
     }
   }
 
+  $reload_command = $::facts['service_provider'] ? {
+    'systemd' => "systemctl ${service_name} reload",
+    default   => "service reload ${service_name}",
+  }
+
   if $manage_service {
     service { $service_name:
-      ensure => $service_ensure,
-      enable => $service_enable,
-      tag    => ['bareos', 'bareos_director'],
+      ensure     => $service_ensure,
+      enable     => $service_enable,
+      hasrestart => true,
+      restart    => $reload_command,
+      tag        => ['bareos', 'bareos_director'],
     }
   }
 

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -46,7 +46,7 @@ class bareos::director (
     service { $service_name:
       ensure     => $service_ensure,
       enable     => $service_enable,
-      hasrestart => true,
+      hasrestart => false,
       restart    => $reload_command,
       tag        => ['bareos', 'bareos_director'],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,13 +21,15 @@
 # @param service_ensure
 #   Service state which should be ensured
 # @param service_enable
-#   Wheter puppet should enable the bareos services
+#   Whether puppet should enable the bareos services
 # @param manage_repo
-#   Wheter puppet should manage the bareos package repository
+#   Whether puppet should manage the bareos package repository
 # @param manage_user
-#   Wheter puppet should manage the bareos user
+#   Whether puppet should manage the bareos user
 # @param package_name
 #   Name of the package which should be installed
+# @param director_service_allow_restart
+#   Whether puppet is allowed to restart the director service. If not it will reload
 #
 class bareos (
   $config_dir                         = $bareos::params::config_dir,
@@ -50,15 +52,16 @@ class bareos (
   Boolean $manage_user                = true,
   String  $package_name               = 'bareos-common',
 
-  $console_package_name  = $bareos::params::console_package_name,
-  $monitor_package_name  = $bareos::params::monitor_package_name,
-  $director_package_name = $bareos::params::director_package_name,
-  $director_service_name = $bareos::params::director_service_name,
-  $director_managed_dirs = $bareos::params::director_managed_dirs,
-  $client_package_name   = $bareos::params::client_package_name,
-  $client_service_name   = $bareos::params::client_service_name,
-  $storage_package_name  = $bareos::params::storage_package_name,
-  $storage_service_name  = $bareos::params::storage_service_name,
+  $console_package_name           = $bareos::params::console_package_name,
+  $monitor_package_name           = $bareos::params::monitor_package_name,
+  $director_package_name          = $bareos::params::director_package_name,
+  $director_service_name          = $bareos::params::director_service_name,
+  $director_service_allow_restart = false,
+  $director_managed_dirs          = $bareos::params::director_managed_dirs,
+  $client_package_name            = $bareos::params::client_package_name,
+  $client_service_name            = $bareos::params::client_service_name,
+  $storage_package_name           = $bareos::params::storage_package_name,
+  $storage_service_name           = $bareos::params::storage_service_name,
 ) inherits bareos::params {
   if $manage_repo {
     class { 'bareos::repository':

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -11,6 +11,7 @@ describe 'bareos::director' do
         it { is_expected.to compile }
         it { is_expected.to contain_class('bareos') }
       end
+
       context 'with catalogs => { test: { db_driver: "sqlite", db_name: "test" }}}' do
         let(:params) do
           {
@@ -30,6 +31,17 @@ describe 'bareos::director' do
             with_db_name('test')
         end
       end
+
+    end
+  end
+  context "on ubuntu-18.04-x86_64" do
+    let(:facts) do
+      {'service_provider' => 'systemd',}.merge(on_supported_os['ubuntu-18.04-x86_64'])
+    end
+  
+    it { is_expected.to compile.with_all_deps }
+    it do
+      is_expected.to contain_service('bareos-dir').with('has_restart' => true, 'restart' => 'systemctl bareos-dir reload')
     end
   end
 end

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -41,7 +41,7 @@ describe 'bareos::director' do
   
     it { is_expected.to compile.with_all_deps }
     it do
-      is_expected.to contain_service('bareos-dir').with('has_restart' => true, 'restart' => 'systemctl bareos-dir reload')
+      is_expected.to contain_service('bareos-dir').with('has_restart' => false, 'restart' => 'systemctl bareos-dir reload')
     end
   end
 end

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -41,7 +41,10 @@ describe 'bareos::director' do
   
     it { is_expected.to compile.with_all_deps }
     it do
-      is_expected.to contain_service('bareos-dir').with('has_restart' => false, 'restart' => 'systemctl bareos-dir reload')
+      is_expected.to contain_service('bareos-dir').with(
+        'hasrestart' => false,
+        'restart'    => 'systemctl reload bareos-dir'
+      )
     end
   end
 end


### PR DESCRIPTION
implement the selection of a reload command to prevent director from beeing hard restarted

Fixes #75 