### PR TITLE
Edit heartbeat_interval variable to accept integer instead of time

### DIFF
--- a/manifests/director/director.pp
+++ b/manifests/director/director.pp
@@ -424,7 +424,7 @@ class bareos::director::director (
       [$dir_port, 'Dir Port', 'port', false],
       [$dir_source_address, 'Dir Source Address', 'address', false],
       [$fd_connect_timeout, 'Fd Connect Timeout', 'time', false],
-      [$heartbeat_interval, 'Heartbeat Interval', 'time', false],
+      [$heartbeat_interval, 'Heartbeat Interval', 'integer', false],
       [$key_encryption_key, 'Key Encryption Key', 'autopassword', false],
       [$log_timestamp_format, 'Log Timestamp Format', 'string', false],
       [$maximum_concurrent_jobs, 'Maximum Concurrent Jobs', 'pint32', false],


### PR DESCRIPTION
Within `/etc/bareos/bareos-dir.d/director/bareos-dir.conf`, `Heartbeat Interval` accepts a value of an integer E.G `60`. However, when attempting to set a value of 60 within the bareos director configuration, the below error is shown during rspec testing
```ruby
Value '60' does not match regex (?i-mx:^(\d+|(\d+\W+(seconds|sec|s|minutes|min|hours|h|days|d|weeks|w|months|m|quarters|q|years|y)\W*)+)$)
```
```puppet
class { 'bareos::director::director':
  heartbeat_interval      => 60
...
}
```
Where 60 is a valid value for the `bareos-dir.conf` [heartbeat_interval](https://docs.bareos.org/Configuration/Director.html#config-Dir_Director_HeartbeatInterval).  The values matched by Puppet's timestamp will not work here.

