### PR TITLE
New release

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@ class bareos (
   $file_group                         = $bareos::params::file_group,
   $file_mode                          = $bareos::params::file_mode,
   $file_dir_mode                      = $bareos::params::file_dir_mode,
-  String  $repo_release               = 'latest',
+  String  $repo_release               = '20',
   Boolean $repo_subscription          = false,
   Optional[String[1]]  $repo_username = undef,
   Optional[String[1]]  $repo_password = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class bareos::params {
   # director
   $director_package_name = [
     'bareos-director',
-    'bareos-director-python-plugin',
+    'bareos-director-python3-plugin',
     'bareos-database-common',
     'bareos-database-mysql',
     'bareos-database-postgresql',
@@ -42,11 +42,11 @@ class bareos::params {
   ]
 
   # filedaemon/client
-  $client_package_name = ['bareos-filedaemon', 'bareos-filedaemon-python-plugin']
+  $client_package_name = ['bareos-filedaemon', 'bareos-filedaemon-python3-plugin']
   $client_service_name = 'bareos-fd'
 
   # storage
-  $storage_package_name = ['bareos-storage', 'bareos-storage-python-plugin', 'bareos-tools']
+  $storage_package_name = ['bareos-storage', 'bareos-storage-python3-plugin', 'bareos-tools']
   $storage_service_name = 'bareos-sd'
 
   # webui

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -19,7 +19,7 @@
 #   The major bareos release version which should be used
 #
 class bareos::repository (
-  String              $release             = 'latest',
+  String              $release             = '20',
   Optional[String[1]] $gpg_key_fingerprint = undef,
   Boolean             $subscription        = false,
   Optional[String]    $username            = undef,
@@ -42,12 +42,12 @@ class bareos::repository (
 
   if $gpg_key_fingerprint {
     $_gpg_key_fingerprint = $gpg_key_fingerprint
-  } elsif $release == 'latest' or versioncmp($release, '18.2') >= 0 {
-    # >= bareos-18.2
+  } elsif versioncmp($release, '20') >= 0 {
+    # >= bareos-20
     if $subscription {
       $_gpg_key_fingerprint = '641A 1497 F1B1 1BEA 945F 840F E5D8 82B2 8657 AE28'
     } else {
-      $_gpg_key_fingerprint = 'A0CF E15F 71F7 9857 4AB3 63DD 1182 83D9 A786 2CEE'
+      $_gpg_key_fingerprint = 'C68B 001F 74D2 F202 43D0 B7A2 0CCB A537 DBE0 83A6'
     }
   } else {
     # >= bareos-15.2


### PR DESCRIPTION
#### Pull Request (PR) description
When looking at the [packages](http://download.bareos.org/bareos/release/20/Debian_10/Packages) I found that the package names have changed to indicate python2 or python3

For example the package named: `bareos-filedaemon-python-plugin` has changed to `bareos-filedaemon-python2-plugin` and for the python3 version the new name is: `bareos-filedaemon-python3-plugin`

As python2 has been end of life since January 2020 I've simply updated this module to use python3

The second change I have made is the "latest" release is no longer available as see here:
http://download.bareos.org/bareos/release/

Because of this I have updated the "latest" release to 20 and updated the gpg key fingerprint to match.
not quite sure where the subscription gpg fingerprint is located on the bareos website so i have left this unchanged.

