### PR TITLE
`runscript_short` allows multiple values

### DIFF
--- a/lib/puppet/parser/functions/bareos_settings.rb
+++ b/lib/puppet/parser/functions/bareos_settings.rb
@@ -18,7 +18,7 @@ module Puppet::Parser::Functions
         raise 'Name of directive config key is invalid' unless directive =~ %r{^[a-zA-Z0-9 ]+$}
 
         # check array if allowed
-        values = if (%w[acl runscript].include?(dirty_type) || dirty_type =~ %r{[_-]list$}) && value_setting.is_a?(Array)
+        values = if (%w[acl runscript runscript_short].include?(dirty_type) || dirty_type =~ %r{[_-]list$}) && value_setting.is_a?(Array)
                    value_setting
                  else
                    [value_setting]

--- a/spec/functions/bareos_settings_spec.rb
+++ b/spec/functions/bareos_settings_spec.rb
@@ -48,7 +48,7 @@ describe 'bareos_settings' do
   end
 
   context 'type is a string with quotes' do
-    %w[audit_command runscript_short autopassword md5password directory string strname device plugin_names].each do |type|
+    %w[audit_command autopassword md5password directory string strname device plugin_names].each do |type|
       it 'runs with compatible values' do
         ['Not a number', 'MyString', '23 free usage of Text.!', 'Special ".-,= Chars'].each do |val|
           is_expected.to run.with_params([val, 'Test', type, true]).and_return("#{indent_default}Test = \"#{val}\"")
@@ -388,6 +388,13 @@ describe 'bareos_settings' do
       is_expected.to run.with_params([val, 'Test', 'string_noquote_list', true]).and_return(result)
     end
 
+    it 'type is runscript_short' do
+      val = %w[first second]
+      result = "#{indent_default}Test = \"first\"
+#{indent_default}Test = \"second\""
+      is_expected.to run.with_params([val, 'Test', 'runscript_short', true]).and_return(result)
+    end
+
     it 'type is acl' do
       val = %w[first second]
       result = "#{indent_default}Test = first
@@ -395,7 +402,7 @@ describe 'bareos_settings' do
       is_expected.to run.with_params([val, 'Test', 'acl', true]).and_return(result)
     end
 
-    it 'type is runcsript' do
+    it 'type is runscript' do
       val = [
         { 'Test A' => 'value' },
         { 'Test B' => 'value' }


### PR DESCRIPTION
#### Pull Request (PR) description

As per the [documentation](https://docs.bareos.org/master/Configuration/CustomizingTheConfiguration.html#datatype-runscript_short), `runscript_short` allows multiple instances and thus should be wrapped accordingly.

#### This Pull Request (PR) fixes the following issues

n/a