### PR TITLE
Disable pam_console_password whent is not set

### DIFF
--- a/templates/webui_directors.erb
+++ b/templates/webui_directors.erb
@@ -12,7 +12,9 @@ catalog = "<%= @catalog %>"
 <%-if @pam_console_name -%>
 pam_console_name = "<%= @pam_console_name %>"
 <%- end -%>
+<%-if @pam_console_password -%>
 pam_console_password = "<%= @pam_console_password %>"
+<%- end -%>
 ; Note: TLS has not been tested and documented, yet.
 ;tls_verify_peer = false
 ;server_can_do_tls = false


### PR DESCRIPTION
#### Pull Request (PR) description
In bareos, if the pam_console_password parameter is defined in the configuration file, bareos tries to use the PAM method.

This results in the inability to log into the webui with an error:
"Sorry, cannot authenticate. Wrong username, password or SSL / TLS handshake failed."

In the logs we can see:
"AUTH: 'admin' is not a defined PAM console on DIR, referer: / bareos-webui / auth / login"


#### This Pull Request (PR) fixes the following issues
- If $pam_console_password is undef it is no transferred in to"/etc/bareos-webui/directors.ini"
- Added repository release key for version 21
