### PR TITLE
Add support for droplet device_type

### DIFF
--- a/lib/puppet/parser/functions/bareos_settings.rb
+++ b/lib/puppet/parser/functions/bareos_settings.rb
@@ -102,7 +102,7 @@ module Puppet::Parser::Functions
         when 'replace_option'
           value_in_array = %w[always ifnewer ifolder never]
         when 'device_type'
-          value_in_array = %w[tape file fifo gfapi rados]
+          value_in_array = %w[tape file fifo gfapi rados droplet]
         when 'compression_algorithm'
           value_in_array = %w[gzip lzo lzfast lz4 lz4hc]
         else

--- a/spec/functions/bareos_settings_spec.rb
+++ b/spec/functions/bareos_settings_spec.rb
@@ -368,7 +368,7 @@ describe 'bareos_settings' do
   context 'type is device_type' do
     %w[device_type].each do |type|
       it 'runs with compatible values' do
-        %w[TAPE file fifo gfapi rados].each do |val|
+        %w[TAPE file fifo gfapi rados droplet].each do |val|
           expect(subject).to run.with_params([val, 'Test', type, true]).and_return("#{indent_default}Test = #{val}")
         end
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Allow device_type of droplet to be added. This is to support, for example, using S3 as a backend for device type.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Fixes bareos_settings function from failing, when attempting to set device_type to droplet for the bareos-sd.d/device/droplet.conf
configuration.
-->
