### PR TITLE
Fix repo URL for different versions of CentOS / AL / RL

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -74,7 +74,7 @@ class bareos::repository (
           $location = "${url}RHEL_${osmajrelease}"
         }
         'Centos', 'Rocky', 'AlmaLinux': {
-          if versioncmp($release, '21') >= 0 {
+          if versioncmp($release, '21') >= 0 and versioncmp($osmajrelease, '8') >= 0 {
             $location = "${url}EL_${osmajrelease}"
           } else {
             $location = "${url}CentOS_${osmajrelease}"


### PR DESCRIPTION
Official BareOS repository has different folders for different CentOS / AlmaLinux / RockyLinux major versions in BareOS v21.

CentOS 7 still has old folder name CentOS_7, where CentOS 8, AL 8 and RL 8 use the new format EL_8. Folder structure can be seen in http://download.bareos.org/bareos/release/21/.

This PR fixes the CentOS 7 exception.