### PR TITLE
Add HTTPS option for repository

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -17,6 +17,8 @@
 #   The major bareos release version which should be used
 # @param password
 #   The major bareos release version which should be used
+# @param https
+#   Wether or not https should be used in repo URL
 #
 class bareos::repository (
   Enum['18.2', '19.2', '20', '21']  $release             = '21',
@@ -24,8 +26,13 @@ class bareos::repository (
   Boolean                           $subscription        = false,
   Optional[String]                  $username            = undef,
   Optional[String]                  $password            = undef,
+  Boolean                           $https               = true,
 ) {
-  $scheme = 'http://'
+  if $https {
+    $scheme = 'https://'
+  } else {
+    $scheme = 'http://'
+  }
   if $subscription {
     if empty($username) or empty($password) {
       fail('For Bareos subscription repos both username and password are required.')

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -153,8 +153,8 @@ class bareos::repository (
         repos    => '',
         key      => $key,
       }
-      Apt::Source['bareos'] -> Package<|tag == 'bareos'|>
-      Class['Apt::Update']  -> Package<|tag == 'bareos'|>
+      Apt::Source['bareos'] -> Package <| provider == 'apt' |>
+      Class['Apt::Update']  -> Package <| provider == 'apt' |>
     }
     default: {
       fail('Operatingsystem is not supported by this module')

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -18,7 +18,7 @@
 # @param password
 #   The major bareos release version which should be used
 # @param https
-#   Wether or not https should be used in repo URL
+#   Whether https should be used in repo URL
 #
 class bareos::repository (
   Enum['18.2', '19.2', '20', '21']  $release             = '21',

--- a/spec/classes/repository_spec.rb
+++ b/spec/classes/repository_spec.rb
@@ -29,10 +29,41 @@ describe 'bareos::repository' do
           it do
             expect(subject).to contain_yumrepo('bareos').
               with_username('test').
-              with_password('test')
+              with_password('test').
+              with_baseurl(%r{^https:})
+          end
+        end
+
+        context 'with https: false' do
+          let(:params) do
+            {
+              https: false,
+            }
+          end
+
+          it { is_expected.to compile }
+
+          it do
+            expect(subject).to contain_yumrepo('bareos').
+              with_baseurl(%r{^http:})
           end
         end
       when 'Debian'
+        context 'with https: false' do
+          let(:params) do
+            {
+              https: false,
+            }
+          end
+
+          it { is_expected.to compile }
+
+          it do
+            expect(subject).to contain_apt__source('bareos').
+              with_location(%r{^http:})
+          end
+        end
+
         case facts[:operatingsystemmajrelease]
         when '20'
           context 'with subscription: true, username: "test", password: "test"' do
@@ -48,7 +79,7 @@ describe 'bareos::repository' do
 
             it do
               expect(subject).to contain_apt__source('bareos').
-                with_location('http://test:test@download.bareos.com/bareos/release/latest/xUbuntu_20.04')
+                with_location('https://test:test@download.bareos.com/bareos/release/latest/xUbuntu_20.04')
             end
           end
         end


### PR DESCRIPTION
Pull Request (PR) description

added a parameter which enables https by default. can be set to false to use http without TLS
This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-bareos/issues/70

Rebase of #71 on current master. All credit is due to [benibr](https://github.com/benibr).