### PR TITLE
Drop support for SQLite3 and MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A good starting point is too look into the profile classes `bareos::profile::dir
 
 Please note, this is only the minimal subset of an bareos configuration. You may use only some of the default configurations such like the schedules, messages, filesets or profiles.
 
-It is highly recommend **not** to use sqlite3 as bareos catalog backend. Please ensure you provide an mysql or postgresql database. See also define `bareos::director::catalog` for the possible database configuration.
+*Note that Bareos >= 21 only supports `postgresql` as a DB backend.*
 
 ```puppet
 # Install and configure an Director Server
@@ -55,10 +55,9 @@ $storage_password = 'Password of the storage instance',
 class { '::bareos::profile::director':
   password     => 'Password of the director instance itself',
   catalog_conf => {
-    'db_driver'   => 'mysql',
     'db_name'     => 'bareos_catalog',
-    'db_address'  => 'fqdn',
-    'db_port'     => 3306,
+    'db_address'  => '127.0.0.1',
+    'db_port'     => 5432,
     'db_user'     => 'user',
     'db_password' => 'password'
   },
@@ -403,7 +402,6 @@ bareos::director::director::name_director: 'example'
 bareos::director::director::password: 'foobar'
 bareos::director::catalogs:
   'testing':
-    db_driver: 'postgresql'
     db_name: 'test'
 bareos::director::clients:
   'alice':

--- a/manifests/director/catalog.pp
+++ b/manifests/director/catalog.pp
@@ -18,8 +18,13 @@
 #   Db Driver
 #
 #   Bareos Datatype: string
-#   Bareos Default: Not set
-#   Required: true
+#   Bareos Default: postgresql
+#   Required: false
+#
+#   This parameter is deprecated. The only valid value under bareos >= 21 is
+#   `postgresql`.
+#
+#   See https://docs.bareos.org/Configuration/Director.html#config-Dir_Catalog_DbDriver
 #
 # [*db_name*]
 #   Db Name

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,9 +20,7 @@ class bareos::params {
     'bareos-director',
     'bareos-director-python-plugin',
     'bareos-database-common',
-    'bareos-database-mysql',
     'bareos-database-postgresql',
-    'bareos-database-sqlite3',
     'bareos-database-tools',
   ]
   $director_service_name = 'bareos-dir'

--- a/manifests/profile/director.pp
+++ b/manifests/profile/director.pp
@@ -4,7 +4,7 @@ class bareos::profile::director (
   $password = 'MyDirectorPasswordPleaseChange',
   $name_dir = 'bareos-dir',
   $catalog_conf = {
-    'db_driver' => 'sqlite3',
+    'db_driver' => 'postgresql',
     'db_name'   => 'bareos_mycatalog',
   },
   $storage_address = 'localhost',

--- a/spec/classes/director_spec.rb
+++ b/spec/classes/director_spec.rb
@@ -14,12 +14,12 @@ describe 'bareos::director' do
         it { is_expected.to contain_class('bareos') }
       end
 
-      context 'with catalogs => { test: { db_driver: "sqlite", db_name: "test" }}}' do
+      context 'with catalogs => { test: { db_driver: "postgresql", db_name: "test" }}}' do
         let(:params) do
           {
             catalogs: {
               test: {
-                db_driver: 'sqlite',
+                db_driver: 'postgresql',
                 db_name: 'test'
               }
             }
@@ -30,7 +30,7 @@ describe 'bareos::director' do
 
         it do
           expect(subject).to contain_bareos__director__catalog('test').
-            with_db_driver('sqlite').
+            with_db_driver('postgresql').
             with_db_name('test')
         end
       end

--- a/spec/defines/director/director_catalog.rb
+++ b/spec/defines/director/director_catalog.rb
@@ -23,7 +23,7 @@ describe 'bareos::director::catalog' do
       context 'with required values' do
         let(:params) do
           {
-            'db_driver' => 'mysql',
+            'db_driver' => 'postgresql',
             'db_name' => 'catalogdb'
           }
         end

--- a/spec/defines/director/director_client_spec.rb
+++ b/spec/defines/director/director_client_spec.rb
@@ -77,7 +77,7 @@ describe 'bareos::director::client' do
         let(:pre_condition) do
           '
           bareos::director::catalog { "name":
-            db_driver => "sqlite3",
+            db_driver => "postgresql",
             db_name   => "test",
           }
           '

--- a/spec/defines/director/director_counter_spec.rb
+++ b/spec/defines/director/director_counter_spec.rb
@@ -38,7 +38,7 @@ describe 'bareos::director::counter' do
         let(:pre_condition) do
           '
           bareos::director::catalog { "name":
-            db_driver => "sqlite3",
+            db_driver => "postgresql",
             db_name   => "test",
           }
           '

--- a/spec/defines/director/director_job_spec.rb
+++ b/spec/defines/director/director_job_spec.rb
@@ -135,7 +135,7 @@ describe 'bareos::director::job' do
           '
           bareos::director::pool { "name": }
           bareos::director::catalog { "name":
-            db_driver => "sqlite3",
+            db_driver => "postgresql",
             db_name   => "test",
           }
           bareos::director::storage { "name":

--- a/spec/defines/director/director_jobdefs_spec.rb
+++ b/spec/defines/director/director_jobdefs_spec.rb
@@ -114,7 +114,7 @@ describe 'bareos::director::jobdefs' do
           '
           bareos::director::pool { "name": }
           bareos::director::catalog { "name":
-            db_driver => "sqlite3",
+            db_driver => "postgresql",
             db_name   => "test",
           }
           bareos::director::storage { "name":

--- a/spec/defines/director/director_pool_spec.rb
+++ b/spec/defines/director/director_pool_spec.rb
@@ -62,7 +62,7 @@ describe 'bareos::director::pool' do
           '
           bareos::director::pool { ["next_pool", "recycle_pool", "scratch_pool"]: }
           bareos::director::catalog { "name":
-            db_driver => "sqlite3",
+            db_driver => "postgresql",
             db_name   => "test",
           }
           bareos::director::storage { "name":


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
- Drop support for the sqlite3 and mysql.  These packages were deprecated in bareos 19.2 and removed in 21.

#### This Pull Request (PR) fixes the following issues
- Fixes #125 
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
