### PR TITLE
make the director::catalog::db_driver param optional

### DIFF
--- a/manifests/director/catalog.pp
+++ b/manifests/director/catalog.pp
@@ -164,7 +164,7 @@ define bareos::director::catalog (
     $_settings = bareos_settings([$name, 'Name', 'name', true],
       [$description, 'Description', 'string', false],
       [$db_address, 'Db Address', 'string', false],
-      [$db_driver, 'Db Driver', 'string', true],
+      [$db_driver, 'Db Driver', 'string', false],
       [$db_name, 'Db Name', 'string', true],
       [$db_password, 'Db Password', 'autopassword', false],
       [$db_port, 'Db Port', 'pint32', false],


### PR DESCRIPTION
Starting with Bareos 23, the `Db Driver` parameter is no longer accepted.  It has been deprecated for some time.  If the parameter exists, the director service won't start.

This PR makes the parameter optional.  The docs at the top of the file already say it isn't required.
```
# [*db_driver*]
#   Db Driver
#
#   Bareos Datatype: string
#   Bareos Default: postgresql
#   Required: false
```