### PR TITLE
Add new versions and update apt package repo handling

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -121,7 +121,7 @@ Data type: `String`
 
 The major bareos release version which should be used
 
-Default value: `'23'`
+Default value: `'25'`
 
 ##### <a name="-bareos--repo_subscription"></a>`repo_subscription`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -88,6 +88,8 @@ The following parameters are available in the `bareos` class:
 * [`repo_subscription`](#-bareos--repo_subscription)
 * [`repo_username`](#-bareos--repo_username)
 * [`repo_password`](#-bareos--repo_password)
+* [`repo_apt_key_content`](#-bareos--repo_apt_key_content)
+* [`repo_apt_key_source`](#-bareos--repo_apt_key_source)
 * [`manage_package`](#-bareos--manage_package)
 * [`manage_service`](#-bareos--manage_service)
 * [`manage_database`](#-bareos--manage_database)
@@ -135,7 +137,7 @@ Default value: `false`
 
 Data type: `Optional[String[1]]`
 
-The major bareos release version which should be used
+The username is required for accessing subscription content
 
 Default value: `undef`
 
@@ -143,7 +145,23 @@ Default value: `undef`
 
 Data type: `Optional[String[1]]`
 
-The major bareos release version which should be used
+The password is required for accessing subscription content
+
+Default value: `undef`
+
+##### <a name="-bareos--repo_apt_key_content"></a>`repo_apt_key_content`
+
+Data type: `Optional[String[1]]`
+
+The apt_key_content is required when using subscription
+
+Default value: `undef`
+
+##### <a name="-bareos--repo_apt_key_source"></a>`repo_apt_key_source`
+
+Data type: `Optional[String[1]]`
+
+The apt_key_source is required when using subscription
 
 Default value: `undef`
 
@@ -2227,27 +2245,20 @@ Manages the bareos repository. Parameters should be configured in the bareos cla
 The following parameters are available in the `bareos::repository` class:
 
 * [`release`](#-bareos--repository--release)
-* [`gpg_key_fingerprint`](#-bareos--repository--gpg_key_fingerprint)
 * [`subscription`](#-bareos--repository--subscription)
 * [`username`](#-bareos--repository--username)
 * [`password`](#-bareos--repository--password)
 * [`https`](#-bareos--repository--https)
+* [`apt_key_content`](#-bareos--repository--apt_key_content)
+* [`apt_key_source`](#-bareos--repository--apt_key_source)
 
 ##### <a name="-bareos--repository--release"></a>`release`
 
-Data type: `Enum['19.2', '20', '21', '22', '23']`
+Data type: `Enum['19.2', '20', '21', '22', '23', '24', '25']`
 
 The major bareos release version which should be used
 
-Default value: `'23'`
-
-##### <a name="-bareos--repository--gpg_key_fingerprint"></a>`gpg_key_fingerprint`
-
-Data type: `Optional[String[1]]`
-
-The GPG fingerprint of the repos key
-
-Default value: `undef`
+Default value: `'25'`
 
 ##### <a name="-bareos--repository--subscription"></a>`subscription`
 
@@ -2280,6 +2291,22 @@ Data type: `Boolean`
 Whether https should be used in repo URL
 
 Default value: `true`
+
+##### <a name="-bareos--repository--apt_key_content"></a>`apt_key_content`
+
+Data type: `Optional[String]`
+
+Required content (or use apt_key_source) for the keyring as it cannot be downloaded here
+
+Default value: `undef`
+
+##### <a name="-bareos--repository--apt_key_source"></a>`apt_key_source`
+
+Data type: `Optional[String]`
+
+Required source (or use apt_key_content) for the keyring as it cannot be downloaded here
+
+Default value: `undef`
 
 ### <a name="bareos--storage"></a>`bareos::storage`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,9 +7,13 @@
 # @param repo_subscription
 #   Activate the (paid) subscription repo. Otherwise the opensource repos will be selected
 # @param repo_username
-#   The major bareos release version which should be used
+#   The username is required for accessing subscription content
 # @param repo_password
-#   The major bareos release version which should be used
+#   The password is required for accessing subscription content
+# @param repo_apt_key_content
+#   The apt_key_content is required when using subscription
+# @param repo_apt_key_source
+#   The apt_key_source is required when using subscription
 # @param manage_package
 #   Whether puppet should handle the installation ob bareos packages
 # @param manage_service
@@ -43,6 +47,8 @@ class bareos (
   Boolean $repo_subscription          = false,
   Optional[String[1]]  $repo_username = undef,
   Optional[String[1]]  $repo_password = undef,
+  Optional[String[1]]  $repo_apt_key_content  = undef,
+  Optional[String[1]]  $repo_apt_key_source  = undef,
   Boolean $manage_package             = true,
   Boolean $manage_service             = true,
   Boolean $manage_database            = true,
@@ -66,10 +72,12 @@ class bareos (
 ) inherits bareos::params {
   if $manage_repo {
     class { 'bareos::repository':
-      release      => $repo_release,
-      subscription => $repo_subscription,
-      username     => $repo_username,
-      password     => $repo_password,
+      release         => $repo_release,
+      subscription    => $repo_subscription,
+      username        => $repo_username,
+      password        => $repo_password,
+      apt_key_content => $repo_apt_key_content,
+      apt_key_source  => $repo_apt_key_source,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,7 @@ class bareos (
   $file_mode                          = $bareos::params::file_mode,
   $file_dir_mode                      = $bareos::params::file_dir_mode,
   Array[String[1]] $user_groups       = [],
-  String  $repo_release               = '23',
+  String  $repo_release               = '25',
   Boolean $repo_subscription          = false,
   Optional[String[1]]  $repo_username = undef,
   Optional[String[1]]  $repo_password = undef,

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -138,7 +138,7 @@ class bareos::repository (
       }
       apt::source { 'bareos':
         location      => [$location],
-        repos         => ['/'],
+        release       => ['/'],
         keyring       => "/etc/apt/keyrings/${key_ring_fn}",
         source_format => 'sources',
       }

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -127,23 +127,7 @@ class bareos::repository (
       if $os  == 'Ubuntu' {
         $location = "${url}xUbuntu_${osrelease}"
       } else {
-        if $osmajrelease == '10' {
-          $location = "${url}Debian_${osmajrelease}"
-        } else {
-          $location = "${url}Debian_${osmajrelease}.0"
-        }
-      }
-      if $subscription {
-        # release key file is not avaiable without login and
-        # apt-key cannot handle username and password in URI
-        $key = {
-          id => regsubst($_gpg_key_fingerprint, ' ', '', 'G'),
-        }
-      } else {
-        $key = {
-          id     => regsubst($_gpg_key_fingerprint, ' ', '', 'G'),
-          source => "${location}/Release.key",
-        }
+        $location = "${url}Debian_${osmajrelease}"
       }
 
       include apt

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -122,7 +122,7 @@ class bareos::repository (
         }
       } else {
         $apt_keyring_args = {
-          source => "${location}/${key_ring_fn}",
+          source => "${location}/Release.key",
         }
       }
       apt::keyring { $key_ring_fn:

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -133,7 +133,7 @@ class bareos::repository (
       include apt
       # this keyring is the same from both the .com and .org repos
       $key_ring_fn = 'bareos-keyring.gpg'
-      apt::keyring { 'bareos-keyring':
+      apt::keyring { $key_ring_fn:
         source => "${location}/${key_ring_fn}",
       }
       apt::source { 'bareos':

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -13,6 +13,8 @@
 #   Whether https should be used in repo URL
 # @param apt_key_content
 #   Required content for the keyring as it cannot be downloaded here
+# @param apt_key_content
+#   Required source for the keyring as it cannot be downloaded here
 #
 class bareos::repository (
   Enum['19.2', '20', '21', '22', '23', '24', '25'] $release = '25',
@@ -21,6 +23,7 @@ class bareos::repository (
   Optional[String]                     $password            = undef,
   Boolean                              $https               = true,
   Optional[String]                     $apt_key_content     = undef,
+  Optional[String]                     $apt_key_source      = undef,
 ) {
   if $https {
     $scheme = 'https://'
@@ -31,8 +34,8 @@ class bareos::repository (
     if empty($username) or empty($password) {
       fail('For Bareos subscription repos both username and password are required.')
     }
-    if $facts['os']['family'] == 'Debian' and empty($apt_key_content) {
-      fail('For Bareos subscription on Debian based systems, you need to specify the keyring content.')
+    if $facts['os']['family'] == 'Debian' and empty($apt_key_content) and empty($apt_key_source) {
+      fail('For Bareos subscription on Debian based systems, you need to specify the keyring content or source.')
     }
     # note the .com
     $dl_hostname = 'download.bareos.com'
@@ -114,6 +117,7 @@ class bareos::repository (
       $key_ring_fn = 'bareos-keyring.gpg'
       if $subscription {
         $apt_keyring_args = {
+          source  => $apt_key_source,
           content => $apt_key_content,
         }
       } else {

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -12,9 +12,9 @@
 # @param https
 #   Whether https should be used in repo URL
 # @param apt_key_content
-#   Required content for the keyring as it cannot be downloaded here
-# @param apt_key_content
-#   Required source for the keyring as it cannot be downloaded here
+#   Required content (or use apt_key_source) for the keyring as it cannot be downloaded here
+# @param apt_key_source
+#   Required source (or use apt_key_content) for the keyring as it cannot be downloaded here
 #
 class bareos::repository (
   Enum['19.2', '20', '21', '22', '23', '24', '25'] $release = '25',

--- a/metadata.json
+++ b/metadata.json
@@ -35,41 +35,46 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
-        "10"
+        "11",
+        "12",
+        "13"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
         "8"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     },
     {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -30,7 +30,7 @@ describe 'bareos' do
             with_subscription(true).
             with_username('test').
             with_password('test'),
-            with_apt_key_content('test_key_content')
+                             with_apt_key_content('test_key_content')
         end
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,12 +13,13 @@ describe 'bareos' do
         it { is_expected.to contain_class('bareos') }
       end
 
-      context 'with repo_subscription: true, repo_username: "test", repo_password: "test"' do
+      context 'with repo_subscription: true, repo_username: "test", repo_password: "test", repo_apt_key_content: "test_key_content"' do
         let(:params) do
           {
             repo_subscription: true,
             repo_username: 'test',
             repo_password: 'test'
+            repo_apt_key_content: 'test_key_content'
           }
         end
 
@@ -29,6 +30,7 @@ describe 'bareos' do
             with_subscription(true).
             with_username('test').
             with_password('test')
+            with_apt_key_content('test_key_content')
         end
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -18,7 +18,7 @@ describe 'bareos' do
           {
             repo_subscription: true,
             repo_username: 'test',
-            repo_password: 'test'
+            repo_password: 'test',
             repo_apt_key_content: 'test_key_content'
           }
         end
@@ -29,7 +29,7 @@ describe 'bareos' do
           expect(subject).to contain_class('bareos::repository').
             with_subscription(true).
             with_username('test').
-            with_password('test')
+            with_password('test'),
             with_apt_key_content('test_key_content')
         end
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -29,8 +29,7 @@ describe 'bareos' do
           expect(subject).to contain_class('bareos::repository').
             with_subscription(true).
             with_username('test').
-            with_password('test'),
-                             with_apt_key_content('test_key_content')
+            with_password('test')
         end
       end
     end

--- a/spec/classes/repository_spec.rb
+++ b/spec/classes/repository_spec.rb
@@ -71,7 +71,7 @@ describe 'bareos::repository' do
               {
                 subscription: true,
                 username: 'test',
-                password: 'test'
+                password: 'test',
                 apt_key_content: 'test'
               }
             end

--- a/spec/classes/repository_spec.rb
+++ b/spec/classes/repository_spec.rb
@@ -66,12 +66,13 @@ describe 'bareos::repository' do
 
         case facts[:operatingsystemmajrelease]
         when '20'
-          context 'with subscription: true, username: "test", password: "test"' do
+          context 'with subscription: true, username: "test", password: "test", apt_key_content: "test"' do
             let(:params) do
               {
                 subscription: true,
                 username: 'test',
                 password: 'test'
+                apt_key_content: 'test'
               }
             end
 
@@ -79,7 +80,7 @@ describe 'bareos::repository' do
 
             it do
               expect(subject).to contain_apt__source('bareos').
-                with_location('https://test:test@download.bareos.com/bareos/release/latest/xUbuntu_20.04')
+                with_location('https://download.bareos.org/current/xUbuntu_24.04')
             end
           end
         end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR corrects a number of issues with repository management with this bareos module.
- updates the basse URL for repos & keys for all OSs, for both subscription and non-subscription releases.
- removes the obosolete apt-key mechanism, now using a  downloaded or provided keyring.
- updates list of supported OSs
- now uses the apt sources format

#### This Pull Request (PR) fixes the following issues
Fixes #59