### PR TITLE
Add Director->User resource support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -53,6 +53,7 @@ Almost the same like `Job`.
 * [`bareos::director::schedule`](#bareos--director--schedule): Provides a means of automatically scheduling a job as well as the ability to override the default level, pool, storage and messages resources. If a schedule resource is not referenced in a job, the jjob can only be run manually. In general, you specify an action to be taken and when.
 * [`bareos::director::storage`](#bareos--director--storage): To define on what physical device the Volumes should be mounted.
 You may have one or more Storage definitions.
+* [`bareos::director::user`](#bareos--director--user): Configure a **PAM-authenticated Console User**.
 * [`bareos::monitor::client`](#bareos--monitor--client): The Client resource defines the attributes of the Clients that are monitored by this Monitor.
 * [`bareos::monitor::director`](#bareos--monitor--director): The Director resource defines the attributes of the Directors that are monitored by this Monitor.
 * [`bareos::monitor::monitor`](#bareos--monitor--monitor): The Monitor resource defines the attributes of the Monitor running on the network. 0The parameters you define here must be configured as a Director resource in Clients and Storages configuration files, and as a Console resource in Directors configuration files.
@@ -9130,6 +9131,181 @@ Data type: `Any`
 Username
 
 Bareos Datatype: string
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+### <a name="bareos--director--user"></a>`bareos::director::user`
+
+Configure a **PAM-authenticated Console User**.
+
+#### Parameters
+
+The following parameters are available in the `bareos::director::user` defined type:
+
+* [`ensure`](#-bareos--director--user--ensure)
+* [`catalog_acl`](#-bareos--director--user--catalog_acl)
+* [`client_acl`](#-bareos--director--user--client_acl)
+* [`command_acl`](#-bareos--director--user--command_acl)
+* [`description`](#-bareos--director--user--description)
+* [`file_set_acl`](#-bareos--director--user--file_set_acl)
+* [`job_acl`](#-bareos--director--user--job_acl)
+* [`plugin_options_acl`](#-bareos--director--user--plugin_options_acl)
+* [`pool_acl`](#-bareos--director--user--pool_acl)
+* [`profile`](#-bareos--director--user--profile)
+* [`schedule_acl`](#-bareos--director--user--schedule_acl)
+* [`storage_acl`](#-bareos--director--user--storage_acl)
+* [`where_acl`](#-bareos--director--user--where_acl)
+
+##### <a name="-bareos--director--user--ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+Whether the config file should be present or absent.
+
+Default value: `present`
+
+##### <a name="-bareos--director--user--catalog_acl"></a>`catalog_acl`
+
+Data type: `Optional[Bareos::List]`
+
+Catalog ACL
+
+Bareos Datatype: acl
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--client_acl"></a>`client_acl`
+
+Data type: `Optional[Bareos::List]`
+
+Client ACL
+
+Bareos Datatype: acl
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--command_acl"></a>`command_acl`
+
+Data type: `Optional[Bareos::List]`
+
+Command ACL
+
+Bareos Datatype: acl
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--description"></a>`description`
+
+Data type: `Optional[String]`
+
+Description
+
+Bareos Datatype: string
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--file_set_acl"></a>`file_set_acl`
+
+Data type: `Optional[Bareos::List]`
+
+File Set ACL
+
+Bareos Datatype: acl
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--job_acl"></a>`job_acl`
+
+Data type: `Optional[Bareos::List]`
+
+Job ACL
+
+Bareos Datatype: acl
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--plugin_options_acl"></a>`plugin_options_acl`
+
+Data type: `Optional[Bareos::List]`
+
+Plugin Options ACL
+
+Bareos Datatype: acl
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--pool_acl"></a>`pool_acl`
+
+Data type: `Optional[Bareos::List]`
+
+Pool ACL
+
+Bareos Datatype: acl
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--profile"></a>`profile`
+
+Data type: `Optional[Bareos::List]`
+
+Profile: Profiles can be assigned to a Console. ACL are checked until either a deny ACL is found or an allow ACL. First the console ACL is checked then any profile the console is linked to.
+
+May be specified as Array.
+Bareos Datatype: resource_list
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--schedule_acl"></a>`schedule_acl`
+
+Data type: `Optional[Bareos::List]`
+
+Schedule ACL
+
+Bareos Datatype: acl
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--storage_acl"></a>`storage_acl`
+
+Data type: `Optional[Bareos::List]`
+
+Storage ACL
+
+Bareos Datatype: acl
+Bareos Default: Not set
+Required: false
+
+Default value: `undef`
+
+##### <a name="-bareos--director--user--where_acl"></a>`where_acl`
+
+Data type: `Optional[Bareos::List]`
+
+Where ACL
+
+Bareos Datatype: acl
 Bareos Default: Not set
 Required: false
 

--- a/manifests/director/console.pp
+++ b/manifests/director/console.pp
@@ -1,4 +1,4 @@
-# @summary 
+# @summary
 #   Configure an **Named Console** aka **Restricted Console**. Both the names and the passwords in these two entries must match much as is the case for Client programs.
 #
 # @param ensure
@@ -228,10 +228,6 @@ define bareos::director::console (
 
   $_resource = 'Console'
   $_resource_dir = 'console'
-
-  unless $ensure in ['present', 'absent'] {
-    fail('Invalid value for ensure')
-  }
 
   if $ensure == 'present' {
     $_require_res_profiles = $profile ? { undef => undef, default => Bareos::Director::Profile[$profile] }

--- a/manifests/director/user.pp
+++ b/manifests/director/user.pp
@@ -109,10 +109,6 @@ define bareos::director::user (
   $_resource = 'User'
   $_resource_dir = 'user'
 
-  unless $ensure in ['present', 'absent'] {
-    fail('Invalid value for ensure')
-  }
-
   if $ensure == 'present' {
     $_require_res_profiles = $profile ? { undef => undef, default => Bareos::Director::Profile[$profile] }
 

--- a/manifests/director/user.pp
+++ b/manifests/director/user.pp
@@ -1,0 +1,151 @@
+# @summary
+#   Configure a **PAM-authenticated Console User**.
+#
+# @param ensure
+#   Whether the config file should be present or absent.
+#
+# @param catalog_acl
+#   Catalog ACL
+#
+#   Bareos Datatype: acl
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param client_acl
+#   Client ACL
+#
+#   Bareos Datatype: acl
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param command_acl
+#   Command ACL
+#
+#   Bareos Datatype: acl
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param description
+#   Description
+#
+#   Bareos Datatype: string
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param file_set_acl
+#   File Set ACL
+#
+#   Bareos Datatype: acl
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param job_acl
+#   Job ACL
+#
+#   Bareos Datatype: acl
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param plugin_options_acl
+#   Plugin Options ACL
+#
+#   Bareos Datatype: acl
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param pool_acl
+#   Pool ACL
+#
+#   Bareos Datatype: acl
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param profile
+#   Profile: Profiles can be assigned to a Console. ACL are checked until either a deny ACL is found or an allow ACL. First the console ACL is checked then any profile the console is linked to.
+#
+#   May be specified as Array.
+#   Bareos Datatype: resource_list
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param schedule_acl
+#   Schedule ACL
+#
+#   Bareos Datatype: acl
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param storage_acl
+#   Storage ACL
+#
+#   Bareos Datatype: acl
+#   Bareos Default: Not set
+#   Required: false
+#
+# @param where_acl
+#   Where ACL
+#
+#   Bareos Datatype: acl
+#   Bareos Default: Not set
+#   Required: false
+#
+define bareos::director::user (
+  Enum['present', 'absent'] $ensure = present,
+  Optional[Bareos::List] $catalog_acl = undef,
+  Optional[Bareos::List] $client_acl = undef,
+  Optional[Bareos::List] $command_acl = undef,
+  Optional[String] $description = undef,
+  Optional[Bareos::List] $file_set_acl = undef,
+  Optional[Bareos::List] $job_acl = undef,
+  Optional[Bareos::List] $plugin_options_acl = undef,
+  Optional[Bareos::List] $pool_acl = undef,
+  Optional[Bareos::List] $profile = undef,
+  Optional[Bareos::List] $schedule_acl = undef,
+  Optional[Bareos::List] $storage_acl = undef,
+  Optional[Bareos::List] $where_acl = undef,
+) {
+  include bareos::director
+
+  $_resource = 'User'
+  $_resource_dir = 'user'
+
+  unless $ensure in ['present', 'absent'] {
+    fail('Invalid value for ensure')
+  }
+
+  if $ensure == 'present' {
+    $_require_res_profiles = $profile ? { undef => undef, default => Bareos::Director::Profile[$profile] }
+
+    $_require_resource = delete_undef_values([
+      $_require_res_profiles,
+    ])
+
+    $_settings = bareos_settings([$name, 'Name', 'name', true],
+      [$description, 'Description', 'string', false],
+      [$catalog_acl, 'Catalog ACL', 'acl', false],
+      [$client_acl, 'Client ACL', 'acl', false],
+      [$command_acl, 'Command ACL', 'acl', false],
+      [$file_set_acl, 'File Set ACL', 'acl', false],
+      [$job_acl, 'Job ACL', 'acl', false],
+      [$plugin_options_acl, 'Plugin Options ACL', 'acl', false],
+      [$pool_acl, 'Pool ACL', 'acl', false],
+      [$profile, 'Profile', 'resource_list', false],
+      [$schedule_acl, 'Schedule ACL', 'acl', false],
+      [$storage_acl, 'Storage ACL', 'acl', false],
+      [$where_acl, 'Where ACL', 'acl', false]
+    )
+  } else {
+    $_require_resource = undef
+  }
+
+  file { "${bareos::director::config_dir}/${_resource_dir}/${name}.conf":
+    ensure  => $ensure,
+    mode    => $bareos::file_mode,
+    owner   => $bareos::file_owner,
+    group   => $bareos::file_group,
+    content => template('bareos/resource.erb'),
+    notify  => Service[$bareos::director::service_name],
+    require => $_require_resource,
+    tag     => ['bareos', 'bareos_director'],
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,8 @@ class bareos::params {
     'bareos-database-tools',
   ]
   $director_service_name = 'bareos-dir'
-  $director_managed_dirs = ['catalog',
+  $director_managed_dirs = [
+    'catalog',
     'client',
     'console',
     'counter',
@@ -37,6 +38,7 @@ class bareos::params {
     'profile',
     'schedule',
     'storage',
+    'user',
   ]
 
   # filedaemon/client

--- a/spec/defines/director/director_user_spec.rb
+++ b/spec/defines/director/director_user_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'bareos::director::user' do
+  let :node do
+    'rspec.puppet.com'
+  end
+  let(:title) { 'name' }
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      filename = '/etc/bareos/bareos-dir.d/user/name.conf'
+
+      context 'with required values' do
+        let(:params) { {} }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('bareos::director') }
+        it { is_expected.to contain_file(filename).with_content(%r{^User \{$}) }
+        it { is_expected.to contain_file(filename).with_content(%r{Name = "name"$}) }
+        it { is_expected.to contain_file(filename).with_tag(%w[bareos bareos_director]) }
+      end
+
+      context 'with all params set' do
+        res = BareosResourceHelper.new('User')
+        res.param('name', 'Name', 'name')
+           .param('description', 'Description', 'string')
+           .param('catalog_acl', 'Catalog ACL', 'acl')
+           .param('client_acl', 'Client ACL', 'acl')
+           .param('command_acl', 'Command ACL', 'acl')
+           .param('file_set_acl', 'File Set ACL', 'acl')
+           .param('job_acl', 'Job ACL', 'acl')
+           .param('plugin_options_acl', 'Plugin Options ACL', 'acl')
+           .param('pool_acl', 'Pool ACL', 'acl')
+           .param('profile', 'Profile', 'resource_list')
+           .param('schedule_acl', 'Schedule ACL', 'acl')
+           .param('storage_acl', 'Storage ACL', 'acl')
+           .param('where_acl', 'Where ACL', 'acl')
+
+        let(:params) { res.params }
+        # required resources
+        let(:pre_condition) do
+          '
+          bareos::director::profile { "name": }
+          '
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file(filename).with_content(res.content) }
+
+        it do
+          expect(subject).to contain_file(filename)
+            .that_notifies('Service[bareos-dir]')
+            .that_requires('Bareos::Director::Profile[name]')
+        end
+      end
+
+      context 'with ensure absent' do
+        let(:params) { { 'ensure' => 'absent' } }
+
+        it { is_expected.to contain_file(filename).with_ensure('absent') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Add support for generating User configuration resources for the BareOS Director.
This resource is required for any Console user to authenticate with PAM (which allows LDAP, local user, or other forms of authentication), including WebUI users, as the WebUI pretends to be a console.

#### This Pull Request (PR) fixes the following issues
Fixes #181 
