### PR TITLE
Update supported OSes and their repository locations

### DIFF
--- a/.fixtures.yaml
+++ b/.fixtures.yaml
@@ -1,8 +1,0 @@
-fixtures:
-  repositories:
-    concat: https://github.com/puppetlabs/puppetlabs-concat.git
-    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
-    apt: https://github.com/puppetlabs/puppetlabs-apt.git
-    yumrepo_core:
-      repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
-      puppet_version: ">= 6.0.0"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,6 @@
+fixtures:
+  repositories:
+    apt: https://github.com/puppetlabs/puppetlabs-apt.git
+    concat: https://github.com/puppetlabs/puppetlabs-concat.git
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+    yumrepo_core: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -38,7 +38,6 @@ class bareos::repository (
   }
 
   $os = $facts['os']['name']
-  $osrelease = $facts['os']['release']['full']
   $osmajrelease = $facts['os']['release']['major']
 
   if $gpg_key_fingerprint {
@@ -81,7 +80,7 @@ class bareos::repository (
           $location = "${url}RHEL_${osmajrelease}"
         }
         'Centos', 'Rocky', 'AlmaLinux': {
-          if versioncmp($release, '21') >= 0 and versioncmp($osmajrelease, '8') >= 0 {
+          if versioncmp($release, '21') >= 0 {
             $location = "${url}EL_${osmajrelease}"
           } else {
             $location = "${url}CentOS_${osmajrelease}"
@@ -122,13 +121,9 @@ class bareos::repository (
         $url = "${scheme}${address}"
       }
       if $os  == 'Ubuntu' {
-        $location = "${url}xUbuntu_${osrelease}"
+        $location = "${url}xUbuntu_${osmajrelease}"
       } else {
-        if $osmajrelease == '10' {
-          $location = "${url}Debian_${osmajrelease}"
-        } else {
-          $location = "${url}Debian_${osmajrelease}.0"
-        }
+        $location = "${url}Debian_${osmajrelease}"
       }
       if $subscription {
         # release key file is not avaiable without login and

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -34,11 +34,22 @@ class bareos::repository (
     # note the .com
     $address = "download.bareos.com/bareos/release/${release}/"
   } else {
-    $address = "download.bareos.org/bareos/release/${release}/"
+    $address = "download.bareos.org/current/${release}/"
+  }
+
+  # We claim to support Amazon Linux 2, which behaves like RHEL 7.  If we encounter versions of
+  # Amazon Linux other than 2, where we can't just pretend it's RHEL 7, BareOS does not offer
+  # repository support, and we should fail out.
+  if $os == 'Amazon' and (versioncmp($facts['os']['release']['major'], '2') != 0) {
+    fail('Operating system has no repository support!')
   }
 
   $os = $facts['os']['name']
-  $osmajrelease = $facts['os']['release']['major']
+  # If it's Amazon Linux 2 (which is the only version left at this point), pretend it's RHEL 7.
+  $osmajrelease = $os == 'Amazon' ? {
+    true    => '7',
+    default => $facts['os']['release']['major'],
+  }
 
   if $gpg_key_fingerprint {
     $_gpg_key_fingerprint = $gpg_key_fingerprint
@@ -75,32 +86,22 @@ class bareos::repository (
   case $os {
     /(?i:redhat|centos|rocky|almalinux|fedora|virtuozzolinux|amazon)/: {
       $url = "${scheme}${address}"
-      case $os {
-        'RedHat', 'VirtuozzoLinux': {
-          $location = "${url}RHEL_${osmajrelease}"
+      if $subscription and versioncmp($release, '20') <= 0 {
+        case $os {
+          'RedHat', 'Amazon', 'VirtuozzoLinux': { $location = "${url}RHEL_${osmajrelease}" }
+          'Fedora':                             { $location = "${url}Fedora_${osmajrelease}" }
+          default:                              { $location = "${url}CentOS_${osmajrelease}" }
         }
-        'Centos', 'Rocky', 'AlmaLinux': {
-          if versioncmp($release, '21') >= 0 {
-            $location = "${url}EL_${osmajrelease}"
-          } else {
-            $location = "${url}CentOS_${osmajrelease}"
-          }
+      } elsif $subscription and versioncmp($release, '21') <= 0 {
+        case $os {
+          'Fedora': { $location = "${url}Fedora_${osmajrelease}" }
+          'Amazon': { $location = "${url}RHEL_7" }
+          default:  { $location = "${url}EL_${osmajrelease}" }
         }
-        'Fedora': {
-          $location = "${url}Fedora_${osmajrelease}"
-        }
-        'Amazon': {
-          case $osmajrelease {
-            '2': {
-              $location = "${url}RHEL_7"
-            }
-            default: {
-              fail('Operatingsystem is not supported by this module')
-            }
-          }
-        }
-        default: {
-          fail('Operatingsystem is not supported by this module')
+      } else {
+        case $os {
+          'Fedora': { $location = "${url}Fedora_${osmajrelease}" }
+          default:  { $location = "${url}EL_${osmajrelease}" }
         }
       }
       yumrepo { 'bareos':
@@ -148,8 +149,6 @@ class bareos::repository (
       Class['Apt::Update']  -> Package <| provider == 'apt' |>
     }
     'windows': {}
-    default: {
-      fail('Operatingsystem is not supported by this module')
-    }
+    default: { fail('Operatingsystem is not supported by this module') }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11",
         "12",
         "13"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -35,41 +35,47 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
-        "10"
+        "11",
+        "12",
+        "13"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 11.0.0"
+      "version_requirement": ">= 10.0.0 < 12.0.0"
     },
     {
       "name": "puppetlabs/concat",
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/repository_spec.rb
+++ b/spec/classes/repository_spec.rb
@@ -13,7 +13,7 @@ describe 'bareos::repository' do
         it { is_expected.to contain_class('bareos::repository') }
       end
 
-      case facts[:osfamily]
+      case facts[:os]['family']
       when 'RedHat'
         context 'with subscription: true, username: "test", password: "test"' do
           let(:params) do
@@ -64,23 +64,23 @@ describe 'bareos::repository' do
           end
         end
 
-        case facts[:operatingsystemmajrelease]
-        when '20'
-          context 'with subscription: true, username: "test", password: "test"' do
-            let(:params) do
-              {
-                subscription: true,
-                username: 'test',
-                password: 'test',
-              }
-            end
+        context 'with subscription: true, username: "test", password: "test"' do
+          let(:params) do
+            {
+              subscription: true,
+              username: 'test',
+              password: 'test',
+            }
+          end
 
-            it { is_expected.to compile }
+          it { is_expected.to compile }
 
-            it do
-              expect(subject).to contain_apt__source('bareos')
-                .with_location('https://test:test@download.bareos.com/bareos/release/latest/xUbuntu_20.04')
-            end
+          it do
+            os_xname = (facts[:os]['name'] == 'Ubuntu') ? 'xUbuntu' : facts[:os]['name']
+            maj_rel = facts[:os]['release']['major']
+
+            expect(subject).to contain_apt__source('bareos')
+              .with_location("https://test:test@download.bareos.com/bareos/release/23/#{os_xname}_#{maj_rel}")
           end
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description
Update the supported OS list, and ensure we're giving supported OSes the correct repository location.  The repository layout for historical versions of BareOS has shifted, and as of BareOS version 22, the layout for Enterprise Linux variants in particular has changed pretty drastically, but has remained consistent since then.  The community repositories only support the latest major version of BareOS, and now also use a slightly different base path.

In addition, smooth out wrinkles in the bareos::repository unit tests, which were previously gated on legacy facts that no longer exist, such that 75% of the tests for the class weren't even being run.  This also removes the gating of tests for Debian and Ubuntu where previously only Ubuntu 20.04 (now no longer supported) _should_ have been tested, but in reality, would never have been tested at all because the case statement that would have caught its major version was written for a format that Facter does not, in fact, return.  Instead, now the tests back-construct the full repo URL for each version, and we should no longer have this issue with tests for this class.

#### This Pull Request (PR) fixes the following issues
This PR does not address any currently open issues, but is partially culled from #184 and lays the groundwork required to address several issues addressed by other parts of that PR.