### PR TITLE
Update supported BareOS versions, default to 25, fix documentation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -136,7 +136,7 @@ Default value: `false`
 
 Data type: `Optional[String[1]]`
 
-The major bareos release version which should be used
+The username is required for accessing subscription content
 
 Default value: `undef`
 
@@ -144,7 +144,7 @@ Default value: `undef`
 
 Data type: `Optional[String[1]]`
 
-The major bareos release version which should be used
+The password is required for accessing subscription content
 
 Default value: `undef`
 
@@ -2262,7 +2262,7 @@ Default value: `false`
 
 Data type: `Optional[String]`
 
-The major bareos release version which should be used
+The username is required for accessing subscription content
 
 Default value: `undef`
 
@@ -2270,7 +2270,7 @@ Default value: `undef`
 
 Data type: `Optional[String]`
 
-The major bareos release version which should be used
+The password is required for accessing subscription content
 
 Default value: `undef`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -122,7 +122,7 @@ Data type: `String`
 
 The major bareos release version which should be used
 
-Default value: `'23'`
+Default value: `'25'`
 
 ##### <a name="-bareos--repo_subscription"></a>`repo_subscription`
 
@@ -2236,11 +2236,11 @@ The following parameters are available in the `bareos::repository` class:
 
 ##### <a name="-bareos--repository--release"></a>`release`
 
-Data type: `Enum['19.2', '20', '21', '22', '23']`
+Data type: `Enum['19.2', '20', '21', '22', '23', '24', '25']`
 
 The major bareos release version which should be used
 
-Default value: `'23'`
+Default value: `'25'`
 
 ##### <a name="-bareos--repository--gpg_key_fingerprint"></a>`gpg_key_fingerprint`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,7 @@ class bareos (
   $file_mode                          = $bareos::params::file_mode,
   $file_dir_mode                      = $bareos::params::file_dir_mode,
   Array[String[1]] $user_groups       = [],
-  String  $repo_release               = '23',
+  String  $repo_release               = '25',
   Boolean $repo_subscription          = false,
   Optional[String[1]]  $repo_username = undef,
   Optional[String[1]]  $repo_password = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,9 +7,9 @@
 # @param repo_subscription
 #   Activate the (paid) subscription repo. Otherwise the opensource repos will be selected
 # @param repo_username
-#   The major bareos release version which should be used
+#   The username is required for accessing subscription content
 # @param repo_password
-#   The major bareos release version which should be used
+#   The password is required for accessing subscription content
 # @param manage_package
 #   Whether puppet should handle the installation ob bareos packages
 # @param manage_service

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -8,9 +8,9 @@
 # @param subscription
 #   Activate the (paid) subscription repo. Otherwise the opensource repos will be selected
 # @param username
-#   The major bareos release version which should be used
+#   The username is required for accessing subscription content
 # @param password
-#   The major bareos release version which should be used
+#   The password is required for accessing subscription content
 # @param https
 #   Whether https should be used in repo URL
 #

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -15,7 +15,7 @@
 #   Whether https should be used in repo URL
 #
 class bareos::repository (
-  Enum['19.2', '20', '21', '22', '23'] $release             = '23',
+  Enum['19.2', '20', '21', '22', '23', '24', '25'] $release = '25',
   Optional[String[1]]                  $gpg_key_fingerprint = undef,
   Boolean                              $subscription        = false,
   Optional[String]                     $username            = undef,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Update the list of supported BareOS major versions, and increment the default major version to latest.  Also fix documentation errors that appear to be copy-pasta issues from years ago.

#### This Pull Request (PR) fixes the following issues
This PR does not fix any currently open issues.  It was formerly part of #184, and lays the groundwork for further issues to be resolved.
