### PR TITLE
Modernize apt, remove hard-coded key fingerprints, and make HTTPS mandatory for repositories

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2249,7 +2249,6 @@ The following parameters are available in the `bareos::repository` class:
 * [`subscription`](#-bareos--repository--subscription)
 * [`username`](#-bareos--repository--username)
 * [`password`](#-bareos--repository--password)
-* [`https`](#-bareos--repository--https)
 * [`apt_key_content`](#-bareos--repository--apt_key_content)
 * [`apt_key_source`](#-bareos--repository--apt_key_source)
 
@@ -2284,14 +2283,6 @@ Data type: `Optional[String]`
 The password is required for accessing subscription content
 
 Default value: `undef`
-
-##### <a name="-bareos--repository--https"></a>`https`
-
-Data type: `Boolean`
-
-Whether https should be used in repo URL
-
-Default value: `true`
 
 ##### <a name="-bareos--repository--apt_key_content"></a>`apt_key_content`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -89,6 +89,8 @@ The following parameters are available in the `bareos` class:
 * [`repo_subscription`](#-bareos--repo_subscription)
 * [`repo_username`](#-bareos--repo_username)
 * [`repo_password`](#-bareos--repo_password)
+* [`repo_apt_key_content`](#-bareos--repo_apt_key_content)
+* [`repo_apt_key_source`](#-bareos--repo_apt_key_source)
 * [`manage_package`](#-bareos--manage_package)
 * [`manage_service`](#-bareos--manage_service)
 * [`manage_database`](#-bareos--manage_database)
@@ -145,6 +147,22 @@ Default value: `undef`
 Data type: `Optional[String[1]]`
 
 The password is required for accessing subscription content
+
+Default value: `undef`
+
+##### <a name="-bareos--repo_apt_key_content"></a>`repo_apt_key_content`
+
+Data type: `Optional[String[1]]`
+
+The apt_key_content is required when using subscription
+
+Default value: `undef`
+
+##### <a name="-bareos--repo_apt_key_source"></a>`repo_apt_key_source`
+
+Data type: `Optional[String[1]]`
+
+The apt_key_source is required when using subscription
 
 Default value: `undef`
 
@@ -2228,11 +2246,12 @@ Manages the bareos repository. Parameters should be configured in the bareos cla
 The following parameters are available in the `bareos::repository` class:
 
 * [`release`](#-bareos--repository--release)
-* [`gpg_key_fingerprint`](#-bareos--repository--gpg_key_fingerprint)
 * [`subscription`](#-bareos--repository--subscription)
 * [`username`](#-bareos--repository--username)
 * [`password`](#-bareos--repository--password)
 * [`https`](#-bareos--repository--https)
+* [`apt_key_content`](#-bareos--repository--apt_key_content)
+* [`apt_key_source`](#-bareos--repository--apt_key_source)
 
 ##### <a name="-bareos--repository--release"></a>`release`
 
@@ -2241,14 +2260,6 @@ Data type: `Enum['19.2', '20', '21', '22', '23', '24', '25']`
 The major bareos release version which should be used
 
 Default value: `'25'`
-
-##### <a name="-bareos--repository--gpg_key_fingerprint"></a>`gpg_key_fingerprint`
-
-Data type: `Optional[String[1]]`
-
-The GPG fingerprint of the repos key
-
-Default value: `undef`
 
 ##### <a name="-bareos--repository--subscription"></a>`subscription`
 
@@ -2281,6 +2292,22 @@ Data type: `Boolean`
 Whether https should be used in repo URL
 
 Default value: `true`
+
+##### <a name="-bareos--repository--apt_key_content"></a>`apt_key_content`
+
+Data type: `Optional[String]`
+
+Required content (or use apt_key_source) for the keyring as it cannot be downloaded here
+
+Default value: `undef`
+
+##### <a name="-bareos--repository--apt_key_source"></a>`apt_key_source`
+
+Data type: `Optional[String]`
+
+Required source (or use apt_key_content) for the keyring as it cannot be downloaded here
+
+Default value: `undef`
 
 ### <a name="bareos--storage"></a>`bareos::storage`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,10 @@
 #   The username is required for accessing subscription content
 # @param repo_password
 #   The password is required for accessing subscription content
+# @param repo_apt_key_content
+#   The apt_key_content is required when using subscription
+# @param repo_apt_key_source
+#   The apt_key_source is required when using subscription
 # @param manage_package
 #   Whether puppet should handle the installation ob bareos packages
 # @param manage_service
@@ -43,6 +47,8 @@ class bareos (
   Boolean $repo_subscription          = false,
   Optional[String[1]]  $repo_username = undef,
   Optional[String[1]]  $repo_password = undef,
+  Optional[String[1]]  $repo_apt_key_content  = undef,
+  Optional[String[1]]  $repo_apt_key_source  = undef,
   Boolean $manage_package             = true,
   Boolean $manage_service             = true,
   Boolean $manage_database            = true,
@@ -66,10 +72,12 @@ class bareos (
 ) inherits bareos::params {
   if $manage_repo {
     class { 'bareos::repository':
-      release      => $repo_release,
-      subscription => $repo_subscription,
-      username     => $repo_username,
-      password     => $repo_password,
+      release         => $repo_release,
+      subscription    => $repo_subscription,
+      username        => $repo_username,
+      password        => $repo_password,
+      apt_key_content => $repo_apt_key_content,
+      apt_key_source  => $repo_apt_key_source,
     }
   }
 

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -9,8 +9,6 @@
 #   The username is required for accessing subscription content
 # @param password
 #   The password is required for accessing subscription content
-# @param https
-#   Whether https should be used in repo URL
 # @param apt_key_content
 #   Required content (or use apt_key_source) for the keyring as it cannot be downloaded here
 # @param apt_key_source
@@ -21,15 +19,9 @@ class bareos::repository (
   Boolean                              $subscription        = false,
   Optional[String]                     $username            = undef,
   Optional[String]                     $password            = undef,
-  Boolean                              $https               = true,
   Optional[String]                     $apt_key_content     = undef,
   Optional[String]                     $apt_key_source      = undef,
 ) {
-  if $https {
-    $scheme = 'https://'
-  } else {
-    $scheme = 'http://'
-  }
   if $subscription {
     if empty($username) or empty($password) {
       fail('For Bareos subscription repos both username and password are required.')
@@ -39,9 +31,9 @@ class bareos::repository (
     }
     # note the .com
     $dl_hostname = 'download.bareos.com'
-    $address = "${dl_hostname}/bareos/release/${release}/"
+    $url = "https://${dl_hostname}/bareos/release/${release}/"
   } else {
-    $address = 'download.bareos.org/current/'
+    $url = 'https://download.bareos.org/current/'
   }
 
   # We claim to support Amazon Linux 2, which behaves like RHEL 7.  If we encounter versions of
@@ -69,7 +61,6 @@ class bareos::repository (
 
   case $os {
     /(?i:redhat|centos|rocky|almalinux|fedora|virtuozzolinux|amazon)/: {
-      $url = "${scheme}${address}"
       if $subscription and versioncmp($release, '20') <= 0 {
         case $os {
           'RedHat', 'Amazon', 'VirtuozzoLinux': { $location = "${url}RHEL_${osmajrelease}" }
@@ -100,7 +91,6 @@ class bareos::repository (
       }
     }
     /(?i:debian|ubuntu)/: {
-      $url = "${scheme}${address}"
       if $subscription {
         apt::auth { $dl_hostname:
           login    => $username,

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -3,8 +3,6 @@
 #
 # @param release
 #   The major bareos release version which should be used
-# @param gpg_key_fingerprint
-#   The GPG fingerprint of the repos key
 # @param subscription
 #   Activate the (paid) subscription repo. Otherwise the opensource repos will be selected
 # @param username
@@ -13,14 +11,19 @@
 #   The password is required for accessing subscription content
 # @param https
 #   Whether https should be used in repo URL
+# @param apt_key_content
+#   Required content (or use apt_key_source) for the keyring as it cannot be downloaded here
+# @param apt_key_source
+#   Required source (or use apt_key_content) for the keyring as it cannot be downloaded here
 #
 class bareos::repository (
   Enum['19.2', '20', '21', '22', '23', '24', '25'] $release = '25',
-  Optional[String[1]]                  $gpg_key_fingerprint = undef,
   Boolean                              $subscription        = false,
   Optional[String]                     $username            = undef,
   Optional[String]                     $password            = undef,
   Boolean                              $https               = true,
+  Optional[String]                     $apt_key_content     = undef,
+  Optional[String]                     $apt_key_source      = undef,
 ) {
   if $https {
     $scheme = 'https://'
@@ -31,10 +34,14 @@ class bareos::repository (
     if empty($username) or empty($password) {
       fail('For Bareos subscription repos both username and password are required.')
     }
+    if $facts['os']['family'] == 'Debian' and empty($apt_key_content) and empty($apt_key_source) {
+      fail('For Bareos subscription on Debian based systems, you need to specify the keyring content or source.')
+    }
     # note the .com
-    $address = "download.bareos.com/bareos/release/${release}/"
+    $dl_hostname = 'download.bareos.com'
+    $address = "${dl_hostname}/bareos/release/${release}/"
   } else {
-    $address = "download.bareos.org/current/${release}/"
+    $address = 'download.bareos.org/current/'
   }
 
   # We claim to support Amazon Linux 2, which behaves like RHEL 7.  If we encounter versions of
@@ -49,29 +56,6 @@ class bareos::repository (
   $osmajrelease = $os == 'Amazon' ? {
     true    => '7',
     default => $facts['os']['release']['major'],
-  }
-
-  if $gpg_key_fingerprint {
-    $_gpg_key_fingerprint = $gpg_key_fingerprint
-  } elsif versioncmp($release, '23') >= 0 {
-    # >= bareos 23
-    $_gpg_key_fingerprint = '5DBE EDB2 E9D0 D238 8684  5C43 D525 2EF6 F51B CCF1'
-  } elsif versioncmp($release, '22') >= 0 {
-    # >= bareos 22
-    $_gpg_key_fingerprint = '5D44 2966 81A7 3289 DBEE  58E4 59E9 68A5 59FE 211E'
-  } elsif versioncmp($release, '21') >= 0 {
-    # >= bareos 21
-    $_gpg_key_fingerprint = '91DA 1DC3 564A E20A 76C4  CA88 E019 57D6 C9FE D482'
-  } elsif versioncmp($release, '20') >= 0 {
-    # >= bareos 20
-    $_gpg_key_fingerprint = 'C68B 001F 74D2 F202 43D0 B7A2 0CCB A537 DBE0 83A6'
-  } else {
-    # >= bareos-18.2
-    if $subscription {
-      $_gpg_key_fingerprint = '641A 1497 F1B1 1BEA 945F 840F E5D8 82B2 8657 AE28'
-    } else {
-      $_gpg_key_fingerprint = 'A0CF E15F 71F7 9857 4AB3 63DD 1182 83D9 A786 2CEE'
-    }
   }
 
   $yum_username = $username ? {
@@ -116,34 +100,40 @@ class bareos::repository (
       }
     }
     /(?i:debian|ubuntu)/: {
+      $url = "${scheme}${address}"
       if $subscription {
-        $url = "${scheme}${username}:${password}@${address}"
-      } else {
-        $url = "${scheme}${address}"
+        apt::auth { $dl_hostname:
+          login    => $username,
+          password => $password,
+        }
       }
       if $os  == 'Ubuntu' {
         $location = "${url}xUbuntu_${osmajrelease}"
       } else {
         $location = "${url}Debian_${osmajrelease}"
       }
+
+      include apt
+      $key_ring_fn = 'bareos-keyring.gpg'
       if $subscription {
-        # release key file is not avaiable without login and
-        # apt-key cannot handle username and password in URI
-        $key = {
-          id => regsubst($_gpg_key_fingerprint, ' ', '', 'G'),
+        $apt_keyring_args = {
+          source  => $apt_key_source,
+          content => $apt_key_content,
         }
       } else {
-        $key = {
-          id     => regsubst($_gpg_key_fingerprint, ' ', '', 'G'),
+        $apt_keyring_args = {
           source => "${location}/Release.key",
         }
       }
-
-      include apt
-      ::apt::source { 'bareos':
-        location => $location,
-        repos    => '/',
-        key      => $key,
+      apt::keyring { $key_ring_fn:
+        * => $apt_keyring_args,
+      }
+      apt::source { 'bareos':
+        location      => [$location],
+        release       => ['/'],
+        keyring       => "/etc/apt/keyrings/${key_ring_fn}",
+        source_format => 'sources',
+        require       => Apt::Keyring[$key_ring_fn],
       }
       Apt::Source['bareos'] -> Package <| provider == 'apt' |>
       Class['Apt::Update']  -> Package <| provider == 'apt' |>

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -123,6 +123,7 @@ class bareos::repository (
         release       => ['/'],
         keyring       => "/etc/apt/keyrings/${key_ring_fn}",
         source_format => 'sources',
+        types         => ['deb',],
         require       => Apt::Keyring[$key_ring_fn],
       }
       Apt::Source['bareos'] -> Package <| provider == 'apt' |>

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 10.0.0 < 12.0.0"
+      "version_requirement": ">= 11.1.0 < 12.0.0"
     },
     {
       "name": "puppetlabs/concat",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,12 +13,13 @@ describe 'bareos' do
         it { is_expected.to contain_class('bareos') }
       end
 
-      context 'with repo_subscription: true, repo_username: "test", repo_password: "test"' do
+      context 'with repo_subscription: true, repo_username: "test", repo_password: "test", repo_apt_key_content: "test_key_content"' do
         let(:params) do
           {
             repo_subscription: true,
             repo_username: 'test',
             repo_password: 'test',
+            repo_apt_key_content: 'test_key_content',
           }
         end
 
@@ -29,6 +30,7 @@ describe 'bareos' do
             .with_subscription(true)
             .with_username('test')
             .with_password('test')
+            .with_apt_key_content('test_key_content')
         end
       end
     end

--- a/spec/classes/repository_spec.rb
+++ b/spec/classes/repository_spec.rb
@@ -10,11 +10,19 @@ describe 'bareos::repository' do
 
       context 'with default values for all parameters' do
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('bareos::repository') }
       end
 
       case facts[:os]['family']
       when 'RedHat'
+        context 'with subscription unset,' do
+          let(:params) { {} }
+
+          it 'contains the community baseurl' do
+            is_expected.to contain_yumrepo('bareos')
+              .with_baseurl(%r{^https://download\.bareos\.org})
+          end
+        end
+
         context 'with subscription: true, username: "test", password: "test"' do
           let(:params) do
             {
@@ -24,46 +32,27 @@ describe 'bareos::repository' do
             }
           end
 
-          it { is_expected.to compile }
+          it { is_expected.to compile.with_all_deps }
 
-          it do
-            expect(subject).to contain_yumrepo('bareos')
+          it 'contains the subscriber baseurl and credentials' do
+            is_expected.to contain_yumrepo('bareos')
               .with_username('test')
               .with_password('test')
-              .with_baseurl(%r{^https:})
-          end
-        end
-
-        context 'with https: false' do
-          let(:params) do
-            {
-              https: false,
-            }
-          end
-
-          it { is_expected.to compile }
-
-          it do
-            expect(subject).to contain_yumrepo('bareos')
-              .with_baseurl(%r{^http:})
+              .with_baseurl(%r{^https://download\.bareos\.com})
           end
         end
       when 'Debian'
-        context 'with https: false' do
-          let(:params) do
-            {
-              https: false,
-            }
-          end
+        context 'with subscription unset,' do
+          let(:params) { {} }
 
-          it { is_expected.to compile }
-
-          it do
+          it 'contains the community source location, but no auth config' do
             os_xname = (facts[:os]['name'] == 'Ubuntu') ? 'xUbuntu' : facts[:os]['name']
             maj_rel = facts[:os]['release']['major']
 
+            is_expected.not_to contain_apt__auth('download.bareos.org')
+            is_expected.to contain_apt__keyring('bareos-keyring.gpg')
             is_expected.to contain_apt__source('bareos')
-              .with_location(["http://download.bareos.org/current/#{os_xname}_#{maj_rel}"])
+              .with_location(["https://download.bareos.org/current/#{os_xname}_#{maj_rel}"])
           end
         end
 
@@ -77,7 +66,7 @@ describe 'bareos::repository' do
             }
           end
 
-          it { is_expected.to compile }
+          it { is_expected.to compile.with_all_deps }
 
           it 'contains the subscriber source location and credentials' do
             os_xname = (facts[:os]['name'] == 'Ubuntu') ? 'xUbuntu' : facts[:os]['name']

--- a/spec/classes/repository_spec.rb
+++ b/spec/classes/repository_spec.rb
@@ -59,28 +59,34 @@ describe 'bareos::repository' do
           it { is_expected.to compile }
 
           it do
-            expect(subject).to contain_apt__source('bareos')
-              .with_location(%r{^http:})
+            os_xname = (facts[:os]['name'] == 'Ubuntu') ? 'xUbuntu' : facts[:os]['name']
+            maj_rel = facts[:os]['release']['major']
+
+            is_expected.to contain_apt__source('bareos')
+              .with_location(["http://download.bareos.org/current/#{os_xname}_#{maj_rel}"])
           end
         end
 
-        context 'with subscription: true, username: "test", password: "test"' do
+        context 'with subscription: true, username: "test", password: "test", apt_key_content: "test"' do
           let(:params) do
             {
               subscription: true,
               username: 'test',
               password: 'test',
+              apt_key_content: 'test',
             }
           end
 
           it { is_expected.to compile }
 
-          it do
+          it 'contains the subscriber source location and credentials' do
             os_xname = (facts[:os]['name'] == 'Ubuntu') ? 'xUbuntu' : facts[:os]['name']
             maj_rel = facts[:os]['release']['major']
 
-            expect(subject).to contain_apt__source('bareos')
-              .with_location("https://test:test@download.bareos.com/bareos/release/23/#{os_xname}_#{maj_rel}")
+            is_expected.to contain_apt__auth('download.bareos.com')
+            is_expected.to contain_apt__keyring('bareos-keyring.gpg')
+            is_expected.to contain_apt__source('bareos')
+              .with_location(["https://download.bareos.com/bareos/release/25/#{os_xname}_#{maj_rel}"])
           end
         end
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Update the way we configure Apt to use the more modern 'sources' format, and handle repository keying in a more modern way.  This obsoletes the old `gpg_key_fingerprint` parameter, which is removed, along with the hard-coded key fingerprints that were breaking automatic key roll-out (as reported in #59).  Make HTTPS transport mandatory, especially since we now fetch and install the keyring for the community repository directly off the internet by default.  Update documentation, tests, and fixtures accordingly.

#### This Pull Request (PR) fixes the following issues
Fixes #59 