### PR TITLE
Do best-effort support per OS family vs. explicit support of specific distributions for repositories

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -64,8 +64,8 @@ class bareos::repository (
     default => $password,
   }
 
-  case $os {
-    /(?i:redhat|centos|rocky|almalinux|fedora|virtuozzolinux|amazon)/: {
+  case $facts['os']['family'] {
+    'RedHat': {
       if $subscription and versioncmp($release, '20') <= 0 {
         case $os {
           'RedHat', 'Amazon', 'VirtuozzoLinux': { $location = "${url}RHEL_${osmajrelease}" }
@@ -95,7 +95,7 @@ class bareos::repository (
         priority => '1',
       }
     }
-    /(?i:debian|ubuntu)/: {
+    'Debian': {
       if $subscription {
         apt::auth { $dl_hostname:
           login    => $username,

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -36,10 +36,15 @@ class bareos::repository (
     $url = 'https://download.bareos.org/current/'
   }
 
-  # We claim to support Amazon Linux 2, which behaves like RHEL 7.  If we encounter versions of
-  # Amazon Linux other than 2, where we can't just pretend it's RHEL 7, BareOS does not offer
-  # repository support, and we should fail out.
-  if $os == 'Amazon' and (versioncmp($facts['os']['release']['major'], '2') != 0) {
+  # Amazon Linux 2 behaves like RHEL 7 and will be End-of-Life on June 30, 2026.  Support for RHEL 7
+  # was dropped starting with BareOS 24.  If we encounter versions of Amazon Linux other than 2,
+  # where we can't just pretend it's RHEL 7, BareOS does not explicitly offer repository support,
+  # and we should fail out.
+  if $facts['os']['name'] == 'Amazon'
+  and (
+    versioncmp($facts['os']['release']['major'], '2') != 0
+    or versioncmp($release, '24') >= 0
+  ) {
     fail('Operating system has no repository support!')
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -76,12 +76,6 @@
         "9",
         "10"
       ]
-    },
-    {
-      "operatingsystem": "Amazon",
-      "operatingsystemrelease": [
-        "2"
-      ]
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add best-effort support for the RedHat and Debian OS families to the repository class.  It should not require a module edit to add a repository that might already work to a system that could already use it.  This fixes #131, and would address the same issue for any other RHEL-derived distro whose major version numbering follows the same sequence as RHEL itself.  

This also adds a bit of logic at the intersections of PR #185 and PR #186 to handle an important detail that fit into neither place: Amazon Linux 2, which is supported mostly just because it acts like RHEL 7, is no longer supported under BareOS 24 and later because those versions dropped support for RHEL 7 (and anything 7-derived in the entire family).  Since our default version is now BareOS 25, it seemed important to update the logic that failed out for any version of Amazon Linux other than 2 so that it would also fail out for BareOS versions 24 and later.  

However, _because of the new default version,_ doing so now makes Amazon Linux 2 fail unit tests by default.  Amazon Linux 2 is EOL [as of the end of next month](https://aws.amazon.com/amazon-linux-2/faqs/#long-term-support--o3nq58).  To fix the tests, I'm removing Amazon Linux 2 from the test battery; the point of this PR is to have best-effort support for distributions in the RedHat and Debian families that haven't been explicitly declared, and under the previous repo logic, Amazon Linux 2 already only had best-effort support.  It should still work as well as it ever did for BareOS subscribers with access to the appropriate historical versions.

#### This Pull Request (PR) fixes the following issues
Fixes #131 