### PR TITLE
[blacksmith] Bump version to 2.0.1-rc0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-bareos",
-  "version": "2.0.0",
+  "version": "2.0.1-rc0",
   "author": "Vox Pupulii <voxpupuli@groups.io>",
   "summary": "Manage and configure a Bareos installation",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
According to the [release workflow documentation](https://voxpupuli.org/docs/releasing_version/#do-the-actual-release), `bundle exec rake release` is supposed to update the version in metadata.json once the release tag is created and the new release is pushed to the Puppet Forge by Github Actions.  When I ran this to do the puppet-bareos v2.0.0 release, it [published to the Puppet Forge](https://forge.puppet.com/modules/puppet/bareos/2.0.0/readme) just fine, but the `master` branch was protected from direct pushes, so the update to metadata.json was rejected.  This just carries that one-line change that the automation couldn't quite get into mainline as intended.